### PR TITLE
Feature/uint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,15 +132,10 @@ azcfg.SetExternalClient(client)
 ```
 
 
-
 **Supported types**
 
 * `string`
 * `bool`
-* `int`
-* `int8`
-* `int16`
-* `int32`
-* `int64`
-* `float32`
-* `float64`
+* `uint`, `uint8`, `uint16`, `uint32`, `uint64`
+* `int`, `int8`, `int16`, `int32`, `int64`
+* `float32`, `float64`

--- a/azcfg.go
+++ b/azcfg.go
@@ -146,6 +146,12 @@ func setValue(v reflect.Value, val string) error {
 			b = false
 		}
 		v.SetBool(b)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		i, err := strconv.ParseUint(val, 10, getBitSize(v.Kind()))
+		if err != nil {
+			return err
+		}
+		v.SetUint(i)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		i, err := strconv.ParseInt(val, 10, getBitSize(v.Kind()))
 		if err != nil {
@@ -168,17 +174,17 @@ func setValue(v reflect.Value, val string) error {
 func getBitSize(k reflect.Kind) int {
 	var bit int
 	switch k {
-	case reflect.Int:
+	case reflect.Uint, reflect.Int:
 		// TODO:
 		// Handle based on OS ARCH, revisit and update.
 		bit = 32
-	case reflect.Int8:
+	case reflect.Uint8, reflect.Int8:
 		bit = 8
-	case reflect.Int16:
+	case reflect.Uint16, reflect.Int16:
 		bit = 16
-	case reflect.Int32, reflect.Float32:
+	case reflect.Uint32, reflect.Int32, reflect.Float32:
 		bit = 32
-	case reflect.Int64, reflect.Float64:
+	case reflect.Uint64, reflect.Int64, reflect.Float64:
 		bit = 64
 	}
 	return bit

--- a/azcfg.go
+++ b/azcfg.go
@@ -175,9 +175,7 @@ func getBitSize(k reflect.Kind) int {
 	var bit int
 	switch k {
 	case reflect.Uint, reflect.Int:
-		// TODO:
-		// Handle based on OS ARCH, revisit and update.
-		bit = 32
+		bit = strconv.IntSize
 	case reflect.Uint8, reflect.Int8:
 		bit = 8
 	case reflect.Uint16, reflect.Int16:

--- a/azcfg_test.go
+++ b/azcfg_test.go
@@ -13,6 +13,9 @@ var (
 		"string":        "new string",
 		"string-ptr":    "new string ptr",
 		"int":           "100",
+		"int64":         "100",
+		"uint":          "100",
+		"uint64":        "100",
 		"float64":       "100",
 		"float64-ptr":   "100",
 		"bool":          "true",
@@ -39,6 +42,9 @@ func TestParse(t *testing.T) {
 				StringPtr: toPtr("initial string ptr"),
 				NestedStructA: NestedStructA{
 					Int:         1,
+					Int64:       1,
+					Uint:        1,
+					Uint64:      1,
 					IntNotParse: 1,
 					NestedNestedStruct: NestedNestedStruct{
 						NestedString: "initial nested string",
@@ -61,7 +67,10 @@ func TestParse(t *testing.T) {
 				BoolPtr:   toPtr(true),
 				NestedStructA: NestedStructA{
 					Int:         100,
+					Int64:       100,
 					IntNotParse: 1,
+					Uint:        100,
+					Uint64:      100,
 					StringSlice: []string{"a", "b", "c"},
 					IntSlice:    []int{1, 2, 3},
 					NestedNestedStruct: NestedNestedStruct{
@@ -120,6 +129,21 @@ func TestGetBitSize(t *testing.T) {
 		input any
 		want  int
 	}{
+		{
+			name: "uint", input: uint(1), want: 32,
+		},
+		{
+			name: "uint8", input: uint8(1), want: 8,
+		},
+		{
+			name: "uint16", input: uint16(1), want: 16,
+		},
+		{
+			name: "uint32", input: uint32(1), want: 32,
+		},
+		{
+			name: "uint64", input: uint64(1), want: 64,
+		},
 		{
 			name: "int", input: int(1), want: 32,
 		},
@@ -207,7 +231,10 @@ type Struct struct {
 }
 
 type NestedStructA struct {
-	Int                int `secret:"int"`
+	Int                int    `secret:"int"`
+	Int64              int64  `secret:"int64"`
+	Uint               uint   `secret:"uint"`
+	Uint64             uint64 `secret:"uint64"`
 	IntNotParse        int
 	StringSlice        []string `secret:"string-slice"`
 	IntSlice           []int    `secret:"int-slice"`

--- a/azcfg_test.go
+++ b/azcfg_test.go
@@ -130,7 +130,7 @@ func TestGetBitSize(t *testing.T) {
 		want  int
 	}{
 		{
-			name: "uint", input: uint(1), want: 32,
+			name: "uint", input: uint(1), want: 64,
 		},
 		{
 			name: "uint8", input: uint8(1), want: 8,
@@ -145,7 +145,7 @@ func TestGetBitSize(t *testing.T) {
 			name: "uint64", input: uint64(1), want: 64,
 		},
 		{
-			name: "int", input: int(1), want: 32,
+			name: "int", input: int(1), want: 64,
 		},
 		{
 			name: "int8", input: int8(1), want: 8,

--- a/azcfg_test.go
+++ b/azcfg_test.go
@@ -3,6 +3,7 @@ package azcfg
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -130,7 +131,7 @@ func TestGetBitSize(t *testing.T) {
 		want  int
 	}{
 		{
-			name: "uint", input: uint(1), want: 64,
+			name: "uint", input: uint(1), want: strconv.IntSize,
 		},
 		{
 			name: "uint8", input: uint8(1), want: 8,
@@ -145,7 +146,7 @@ func TestGetBitSize(t *testing.T) {
 			name: "uint64", input: uint64(1), want: 64,
 		},
 		{
-			name: "int", input: int(1), want: 64,
+			name: "int", input: int(1), want: strconv.IntSize,
 		},
 		{
 			name: "int8", input: int8(1), want: 8,


### PR DESCRIPTION
- Add support for `uint`, `uint8`, `uint16`, `uint32` and `uint64`.
- Fix so that bit size of `uint` and `int` is correct depending on architecture.

Closes #4.