### PR TITLE
Rename interface KeyVaultClient to VaultClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ azcfg.SetClientOptions(&azcfg.ClientOptions{
 })
 
 // Setting an external client for Azure Key Vault. Provided client must implement
-// KeyVaultClient. Useful for stubbing dependencies when testing applications
+// VaultClient. Useful for stubbing dependencies when testing applications
 // using this library.
 azcfg.SetExternalClient(client)
 ```

--- a/azcfg.go
+++ b/azcfg.go
@@ -18,7 +18,7 @@ const (
 
 // Parse secrets from an Azure Key Vault into a struct.
 func Parse(v any) error {
-	var client KeyVaultClient
+	var client VaultClient
 	if opts.externalClient == nil {
 		var err error
 		var cred azcore.TokenCredential
@@ -51,13 +51,13 @@ func Parse(v any) error {
 	return parse(v, client)
 }
 
-// KeyVaultClient is the interface that wraps around method GetSecrets.
-type KeyVaultClient interface {
+// VaultClient is the interface that wraps around method GetSecrets.
+type VaultClient interface {
 	GetSecrets(names []string) (map[string]string, error)
 }
 
 // Parse secrets into the configuration.
-func parse(d any, client KeyVaultClient) error {
+func parse(d any, client VaultClient) error {
 	v := reflect.ValueOf(d)
 	if v.Kind() != reflect.Pointer {
 		return errors.New("must provide a pointer to a struct")

--- a/options.go
+++ b/options.go
@@ -52,7 +52,7 @@ var (
 // options contains options for the package.
 type options struct {
 	client         client
-	externalClient KeyVaultClient
+	externalClient VaultClient
 }
 
 // client contains options for the Key Vault client.
@@ -119,8 +119,8 @@ func SetTimeout(d time.Duration) {
 
 // SetExternalClient sets an external alternative client to
 // use for Azure Key Vault requests. Must implement
-// KeyVaultClient.
-func SetExternalClient(client KeyVaultClient) {
+// VaultClient.
+func SetExternalClient(client VaultClient) {
 	opts.externalClient = client
 }
 


### PR DESCRIPTION
Rename the interface `KeyVaultClient` to `VaultClient`. Closes #11. 