### PR TITLE
feat!: Parser type and new names for option functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+## v0.5.0
+
+### What's changed
+
+* feat!: Add required option on secret tags
+
 ## v0.4.1
+
+### What's changed
 
 * fix: Update dependencies
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The behaviour of the module can be modified with the help of various options.
 azcfg.SetOptions(&azcfg.Options{
     Client: client,         // Defaults to nil, the built-in secrets client.
     Credential: cred,       // Defaults to nil, the built-in Azure credential authentication flow.
-    Vault: "vault-name"     // Defaults to "", which will check environment variables.
+    Vault: "vault"          // Defaults to "", which will check environment variables.
     Concurrency: 20,        // Defaults to 10.
     Timeout: duration,      // Defaults to time.Millisecond * 1000 * 10 (10 seconds)
 })
@@ -209,7 +209,7 @@ azcfg.SetCredential(cred)
 
 
 // Setting secrets vault name:
-azcfg.SetVault("vault-name")
+azcfg.SetVault("vault")
 
 
 // Setting concurrent calls for the client (defaults to 10):

--- a/README.md
+++ b/README.md
@@ -121,19 +121,47 @@ package main
 func main() {
     cfg := config{}
     if err := azcfg.Parse(&cfg, &azcfg.Options{
-        Secrets: &azcfg.SecretOptions{
-            Client: client,
-            Vault: "vault"
-        }
-        AzureCredential: cred,
+        Client: client,
+        Credential: cred,
+        Vault: "vault",
         Concurrency: 20,
         Timeout: time.Millisecond * 1000 * 20
-    })
+    }); err != nil {
+        // Handle error.
+    }
 }
 ```
 
+An independent `Parser` can be created and passed around inside of the application.
 
-**Note**: When using options `Secrets.Client` it will take precedence over `AzureCredential`. Use one of them.
+```go
+package main
+
+func main() {
+    parser := azcfg.NewParser()
+
+    cfg := config{}
+    if err := parser.Parse(&cfg); err != nil {
+        // Handle error.
+    }
+}
+```
+
+Both the `NewParser` and the `Parse` method on the `Parser` supports `Options` as in the examples
+for the package level `Parse` function.
+
+```go
+package main
+
+func main() {
+    parser := azcfg.NewParser(azcfg.Options{})
+
+    cfg := config{}
+    if err := parser.Parse(azcfg.Options{}); err != nil {
+        // Handle error.
+    }
+}
+```
 
 For supported options see `Options` struct.
 
@@ -153,6 +181,22 @@ For supported options see `Options` struct.
 The behaviour of the module can be modified with the help of various options.
 
 ```go
+// Setting options for the package:
+azcfg.SetOptions(&azcfg.Options{
+    Client: client,         // Defaults to nil, the built-in secrets client.
+    Credential: cred,       // Defaults to nil, the built-in Azure credential authentication flow.
+    Vault: "vault-name"     // Defaults to "", which will check environment variables.
+    Concurrency: 20,        // Defaults to 10.
+    Timeout: duration,      // Defaults to time.Millisecond * 1000 * 10 (10 seconds)
+})
+
+
+// Setting a client for Azure Key Vault. Provided client must implement
+// Client. Useful for stubbing dependencies when testing applications
+// using this library.
+azcfg.SetClient(client)
+
+
 // Setting credential. See example for supported credential types and how to set the at:
 // https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#readme-credential-types.
 // This is useful when the same credentials should be used through the entire application,
@@ -161,32 +205,20 @@ cred, err := azidentity.<FunctionForCredentialType>
 if err != nil {
     // Handle error.
 }
-azcfg.SetAzureCredential(cred)
+azcfg.SetCredential(cred)
+
 
 // Setting secrets vault name:
-azcfg.SetSecretsVault("vault-name")
+azcfg.SetVault("vault-name")
+
 
 // Setting concurrent calls for the client (defaults to 10):
 azcfg.SetConcurrency(20)
 
+
 // Setting timeout for the total amount of requests (default to 10 seconds):
 azcfg.SetTimeout(time.Millsecond * 1000 * 20)
 
-// Setting options for the package:
-azcfg.SetOptions(&azcfg.Options{
-    Secrets: SecretsOptions{
-        Client: SecretsClient // Defaults to nil, the built-in secrets client.
-        Vault: "vault-name",    // Defaults to "", which will check environment variables.
-    }
-    AzureCredential: cred,       // Defaults to nil, the built-in Azure credential auth.
-    Concurrency: 20,        // Defaults to 10.
-    Timeout: duration,      // Defaults to time.Millisecond * 1000 * 10 (10 seconds)
-})
-
-// Setting a client for Azure Key Vault. Provided client must implement
-// SecretsClient. Useful for stubbing dependencies when testing applications
-// using this library.
-azcfg.SetSecretsClient(client)
 
 // The "Set"-functions are chainable (with the exception of SetOptions), and can be called like so:
 azcfg.SetConcurrency(20).SetTimeout(time.Millisecond * 1000 * 10)
@@ -203,4 +235,3 @@ type Example struct {
     FieldB `secret:"field-b,required"`
 }
 ```
-

--- a/azcfg.go
+++ b/azcfg.go
@@ -13,22 +13,21 @@ const (
 	required   = "required"
 )
 
-// Parse secrets from an Azure Key Vault into a struct.
-func Parse(v any, o ...Options) error {
-	client, err := evalClient(
-		evalOptions(o...),
-		newAzureCredential,
-		newKeyvaultClient,
-	)
-	if err != nil {
-		return err
+var (
+	// parser is the package level Parser.
+	parser = &Parser{
+		concurrency: defaultConcurrency,
+		timeout:     defaultTimeout,
 	}
+)
 
-	return parse(v, client)
+// Parse secrets from an Azure Key Vault into a struct.
+func Parse(v any, options ...Options) error {
+	return parser.Parse(v, options...)
 }
 
 // Parse secrets into the configuration.
-func parse(d any, client SecretsClient) error {
+func parse(d any, client Client) error {
 	v := reflect.ValueOf(d)
 	if v.Kind() != reflect.Pointer {
 		return errors.New("must provide a pointer to a struct")

--- a/azcfg.go
+++ b/azcfg.go
@@ -14,7 +14,7 @@ const (
 )
 
 var (
-	// parser is the package level Parser.
+	// parser is the package level *Parser.
 	parser = &Parser{
 		concurrency: defaultConcurrency,
 		timeout:     defaultTimeout,

--- a/internal/keyvault/keyvault.go
+++ b/internal/keyvault/keyvault.go
@@ -89,9 +89,9 @@ func (c Client) GetSecrets(names []string) (map[string]string, error) {
 
 // secretResult contains the results from a GetSecret call.
 type secretResult struct {
+	err   error
 	name  string
 	value string
-	err   error
 }
 
 // getSecrets performs calls to the target Azure Key Vault concurrently. It

--- a/options.go
+++ b/options.go
@@ -18,8 +18,7 @@ var (
 	defaultTimeout = time.Millisecond * 1000 * 10
 )
 
-// Options contains options for a package level Parse operation, and
-// options for an instance of Parse created with NewParser.
+// Options contains settings for Parse operations and for instances of Parser created with NewParser.
 type Options struct {
 	// Client is the client used to retrieve secrets. Used to override the default
 	// Client.

--- a/options.go
+++ b/options.go
@@ -82,9 +82,9 @@ var (
 	}
 )
 
-// getVaultFromEnvironment checks the environment if any of the variables AZURE_KEY_VAULT,
+// vaultFromEnvironment checks the environment if any of the variables AZURE_KEY_VAULT,
 // AZURE_KEY_VAULT_NAME, AZURE_KEYVAULT or AZURE_KEYVAULT_NAME is set.
-func getVaultFromEnvironment() (string, error) {
+func vaultFromEnvironment() (string, error) {
 	for _, v := range envKeyVault {
 		if len(os.Getenv(v)) != 0 {
 			return os.Getenv(v), nil
@@ -100,16 +100,19 @@ func evalOptions(p *Parser, o ...Options) *Parser {
 		if o.Client != nil {
 			p.client = o.Client
 		}
-		if len(o.Vault) != 0 {
-			p.vault = o.Vault
-		}
 
 		if o.Credential != nil {
 			p.credential = o.Credential
 		}
+
+		if len(o.Vault) != 0 {
+			p.vault = o.Vault
+		}
+
 		if o.Concurrency != 0 {
 			p.concurrency = o.Concurrency
 		}
+
 		if o.Timeout != 0 {
 			p.timeout = o.Timeout
 		}
@@ -153,7 +156,7 @@ func evalClient(p *Parser, azureCredentialFn azureCredentialFunc, keyvaultClient
 	}
 
 	if len(p.vault) == 0 {
-		p.vault, err = getVaultFromEnvironment()
+		p.vault, err = vaultFromEnvironment()
 		if err != nil {
 			return p, err
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -117,7 +117,7 @@ func TestSetTimeout(t *testing.T) {
 	resetOptions()
 }
 
-func TestGetVaultFromEnvironment(t *testing.T) {
+func TestVaultFromEnvironment(t *testing.T) {
 	var tests = []struct {
 		name    string
 		input   map[string]string
@@ -159,11 +159,11 @@ func TestGetVaultFromEnvironment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			setEnv(test.input)
-			got, gotErr := getVaultFromEnvironment()
+			got, gotErr := vaultFromEnvironment()
 			unsetEnv(test.input)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("getVaultFromEnvironment() = unexpected result, (-want, +got)\n%s\n", diff)
+				t.Errorf("vaultFromEnvironment() = unexpected result, (-want, +got)\n%s\n", diff)
 			}
 
 			if test.wantErr != nil && gotErr == nil {

--- a/options_test.go
+++ b/options_test.go
@@ -353,9 +353,9 @@ func TestEvalClient(t *testing.T) {
 			wantErr: errors.New("error"),
 		},
 		{
-			name:    "secrets client error",
+			name:    "client error",
 			input:   &Parser{},
-			options: evalClientOptions{ClientErr: errors.New("error")},
+			options: evalClientOptions{clientErr: errors.New("error")},
 			env: map[string]string{
 				"AZURE_KEYVAULT_NAME": "vault-name",
 			},
@@ -376,7 +376,7 @@ func TestEvalClient(t *testing.T) {
 					return &mockAzureCredential{}, test.options.credentialErr
 				},
 				func(vault string, cred azcore.TokenCredential, options *keyvault.ClientOptions) (Client, error) {
-					return &mockKeyVaultClient{}, test.options.ClientErr
+					return &mockKeyVaultClient{}, test.options.clientErr
 				},
 			)
 
@@ -395,7 +395,7 @@ func TestEvalClient(t *testing.T) {
 
 type evalClientOptions struct {
 	credentialErr error
-	ClientErr     error
+	clientErr     error
 }
 
 func resetOptions() {

--- a/options_test.go
+++ b/options_test.go
@@ -17,7 +17,7 @@ func TestSetOptions(t *testing.T) {
 	var tests = []struct {
 		name  string
 		input *Options
-		want  *options
+		want  *Parser
 	}{
 		{
 			name: "full",
@@ -27,11 +27,9 @@ func TestSetOptions(t *testing.T) {
 				Concurrency: 20,
 				Timeout:     time.Millisecond * 1000 * 20,
 			},
-			want: &options{
-				secrets: secrets{
-					vault:      "vault-name",
-					credential: mockAzureCredential{},
-				},
+			want: &Parser{
+				vault:       "vault-name",
+				credential:  mockAzureCredential{},
 				concurrency: 20,
 				timeout:     time.Millisecond * 1000 * 20,
 			},
@@ -42,11 +40,9 @@ func TestSetOptions(t *testing.T) {
 				Credential: mockAzureCredential{},
 				Vault:      "vault-name",
 			},
-			want: &options{
-				secrets: secrets{
-					vault:      "vault-name",
-					credential: mockAzureCredential{},
-				},
+			want: &Parser{
+				vault:       "vault-name",
+				credential:  mockAzureCredential{},
 				concurrency: defaultConcurrency,
 				timeout:     defaultTimeout,
 			},
@@ -57,7 +53,7 @@ func TestSetOptions(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			SetOptions(test.input)
 
-			if diff := cmp.Diff(test.want, pkgOpts, cmp.AllowUnexported(options{}, secrets{})); diff != "" {
+			if diff := cmp.Diff(test.want, parser, cmp.AllowUnexported(Parser{})); diff != "" {
 				t.Errorf("SetOptions(%+v) = unexpected result, (-want, +got)\n%s\n", test.input, diff)
 			}
 			resetOptions()
@@ -65,36 +61,36 @@ func TestSetOptions(t *testing.T) {
 	}
 }
 
-func TestSetSecretsClient(t *testing.T) {
+func TestSetClient(t *testing.T) {
 	want := mockKeyVaultClient{}
-	SetSecretsClient(mockKeyVaultClient{})
-	got := pkgOpts.secrets.client
+	SetClient(mockKeyVaultClient{})
+	got := parser.client
 
 	if diff := cmp.Diff(want, got, cmp.AllowUnexported(mockKeyVaultClient{})); diff != "" {
-		t.Errorf("SetSecretsClient(%+v) = unexpected result, (-want, +got)\n%s\n", mockKeyVaultClient{}, diff)
+		t.Errorf("SetClient(%+v) = unexpected result, (-want, +got)\n%s\n", mockKeyVaultClient{}, diff)
 	}
 	resetOptions()
 }
 
-func TestSetSecretsVault(t *testing.T) {
+func TestVault(t *testing.T) {
 	want := "testvault"
-	SetSecretsVault(want)
-	got := pkgOpts.secrets.vault
+	SetVault(want)
+	got := parser.vault
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("SetSecretsVault(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
+		t.Errorf("SetVault(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
 	}
 	resetOptions()
 }
 
-func TestSetAzureCredential(t *testing.T) {
-	SetAzureCredential(mockAzureCredential{})
+func TestSetCredential(t *testing.T) {
+	SetCredential(mockAzureCredential{})
 	want := "token"
-	token, _ := pkgOpts.secrets.credential.GetToken(context.TODO(), policy.TokenRequestOptions{})
+	token, _ := parser.credential.GetToken(context.TODO(), policy.TokenRequestOptions{})
 	got := token.Token
 
 	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("SetAzureCredential(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
+		t.Errorf("SetCredential(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
 	}
 	resetOptions()
 }
@@ -102,7 +98,7 @@ func TestSetAzureCredential(t *testing.T) {
 func TestSetConcurrency(t *testing.T) {
 	want := 20
 	SetConcurrency(want)
-	got := pkgOpts.concurrency
+	got := parser.concurrency
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("SetConcurrency(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
@@ -113,7 +109,7 @@ func TestSetConcurrency(t *testing.T) {
 func TestSetTimeout(t *testing.T) {
 	want := time.Millisecond * 1000 * 20
 	SetTimeout(want)
-	got := pkgOpts.timeout
+	got := parser.timeout
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("SetTimeout(%q) = unexpected result, (-want, +got)\n%s\n", want, diff)
@@ -121,7 +117,7 @@ func TestSetTimeout(t *testing.T) {
 	resetOptions()
 }
 
-func TestGetSecretsVaultFromEnvironment(t *testing.T) {
+func TestGetVaultFromEnvironment(t *testing.T) {
 	var tests = []struct {
 		name    string
 		input   map[string]string
@@ -163,11 +159,11 @@ func TestGetSecretsVaultFromEnvironment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			setEnv(test.input)
-			got, gotErr := getSecretsVaultFromEnvironment()
+			got, gotErr := getVaultFromEnvironment()
 			unsetEnv(test.input)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
-				t.Errorf("getSecretsVaultFromEnvironment() = unexpected result, (-want, +got)\n%s\n", diff)
+				t.Errorf("getVaultFromEnvironment() = unexpected result, (-want, +got)\n%s\n", diff)
 			}
 
 			if test.wantErr != nil && gotErr == nil {
@@ -179,19 +175,17 @@ func TestGetSecretsVaultFromEnvironment(t *testing.T) {
 }
 
 func TestSetChaining(t *testing.T) {
-	want := &options{
-		secrets: secrets{
-			client:     &mockKeyVaultClient{},
-			credential: &mockAzureCredential{},
-			vault:      "test-vault",
-		},
+	want := &Parser{
+		client:      &mockKeyVaultClient{},
+		credential:  &mockAzureCredential{},
+		vault:       "test-vault",
 		concurrency: 20,
 		timeout:     time.Millisecond * 1000 * 20,
 	}
 
-	got := SetSecretsClient(&mockKeyVaultClient{}).SetSecretsVault("test-vault").SetAzureCredential(&mockAzureCredential{}).SetConcurrency(20).SetTimeout(time.Millisecond * 1000 * 20).SetSecretsClient(&mockKeyVaultClient{})
+	got := SetClient(&mockKeyVaultClient{}).SetVault("test-vault").SetCredential(&mockAzureCredential{}).SetConcurrency(20).SetTimeout(time.Millisecond * 1000 * 20).SetClient(&mockKeyVaultClient{})
 
-	if diff := cmp.Diff(want, got, cmp.AllowUnexported(options{}, secrets{}, mockKeyVaultClient{}, mockAzureCredential{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(Parser{}, mockKeyVaultClient{}, mockAzureCredential{})); diff != "" {
 		t.Errorf("Unexpected result, (-want, +got)\n%s\n", diff)
 	}
 
@@ -200,84 +194,77 @@ func TestSetChaining(t *testing.T) {
 
 func TestEvalOptions(t *testing.T) {
 	var tests = []struct {
-		name        string
-		input       []Options
-		want        *options
-		wantPkgOpts *options
+		name  string
+		input struct {
+			parser  *Parser
+			options []Options
+		}
+		want *Parser
 	}{
 		{
-			name:  "package options",
-			input: []Options{},
-			want: &options{
-				secrets:     secrets{},
-				concurrency: defaultConcurrency,
-				timeout:     defaultTimeout,
+			name: "package options",
+			input: struct {
+				parser  *Parser
+				options []Options
+			}{
+				parser:  &Parser{},
+				options: []Options{},
 			},
-			wantPkgOpts: &options{
-				secrets:     secrets{},
-				concurrency: 10,
-				timeout:     time.Millisecond * 1000 * 10,
-			},
+			want: &Parser{},
 		},
 		{
 			name: "provided options (client)",
-			input: []Options{
-				{
-					SecretsClient: mockKeyVaultClient{},
-					Vault:         "vault-name",
-					Concurrency:   5,
-					Timeout:       time.Second * 20,
+			input: struct {
+				parser  *Parser
+				options []Options
+			}{
+				parser: &Parser{},
+				options: []Options{
+					{
+						Client:      mockKeyVaultClient{},
+						Vault:       "vault-name",
+						Concurrency: 5,
+						Timeout:     time.Second * 20,
+					},
 				},
 			},
-			want: &options{
-				secrets: secrets{
-					client: mockKeyVaultClient{},
-					vault:  "vault-name",
-				},
+			want: &Parser{
+				client:      mockKeyVaultClient{},
+				vault:       "vault-name",
 				concurrency: 5,
 				timeout:     time.Second * 20,
-			},
-			wantPkgOpts: &options{
-				secrets:     secrets{},
-				concurrency: 10,
-				timeout:     time.Millisecond * 1000 * 10,
 			},
 		},
 		{
 			name: "provided options (credential)",
-			input: []Options{
-				{
-					Credential:  &mockAzureCredential{},
-					Vault:       "vault-name",
-					Concurrency: 5,
-					Timeout:     time.Second * 20,
+			input: struct {
+				parser  *Parser
+				options []Options
+			}{
+				parser: &Parser{},
+				options: []Options{
+					{
+						Credential:  &mockAzureCredential{},
+						Vault:       "vault-name",
+						Concurrency: 5,
+						Timeout:     time.Second * 20,
+					},
 				},
 			},
-			want: &options{
-				secrets: secrets{
-					credential: &mockAzureCredential{},
-					vault:      "vault-name",
-				},
+			want: &Parser{
+				credential:  &mockAzureCredential{},
+				vault:       "vault-name",
 				concurrency: 5,
 				timeout:     time.Second * 20,
-			},
-			wantPkgOpts: &options{
-				secrets:     secrets{},
-				concurrency: 10,
-				timeout:     time.Millisecond * 1000 * 10,
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := evalOptions(test.input...)
+			got := evalOptions(test.input.parser, test.input.options...)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(options{}, secrets{}, mockKeyVaultClient{})); diff != "" {
-				t.Errorf("evalOptions(%+v) = unexpected result, (-want, +got)\n%s\n", test.input, diff)
-			}
-
-			if diff := cmp.Diff(test.wantPkgOpts, pkgOpts, cmp.AllowUnexported(options{}, secrets{}, mockKeyVaultClient{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Parser{}, mockKeyVaultClient{})); diff != "" {
 				t.Errorf("evalOptions(%+v) = unexpected result, (-want, +got)\n%s\n", test.input, diff)
 			}
 
@@ -289,92 +276,93 @@ func TestEvalOptions(t *testing.T) {
 func TestEvalClient(t *testing.T) {
 	var tests = []struct {
 		name    string
-		input   *options
+		input   *Parser
 		options evalClientOptions
 		env     map[string]string
-		want    SecretsClient
+		want    *Parser
 		wantErr error
 	}{
 		{
 			name: "client is provided",
-			input: &options{
-				secrets: secrets{
-					client: &mockKeyVaultClient{},
-				},
+			input: &Parser{
+				client: &mockKeyVaultClient{},
 			},
 			options: evalClientOptions{},
 			env:     nil,
-			want:    &mockKeyVaultClient{},
+			want: &Parser{
+				client: &mockKeyVaultClient{},
+			},
 			wantErr: nil,
 		},
 		{
 			name: "credentials and vault are provided",
-			input: &options{
-				secrets: secrets{
-					credential: &mockAzureCredential{},
-					vault:      "vault-name",
-				},
+			input: &Parser{
+				credential: &mockAzureCredential{},
+				vault:      "vault-name",
 			},
 			options: evalClientOptions{},
 			env:     nil,
-			want:    &mockKeyVaultClient{},
+			want: &Parser{
+				client:     &mockKeyVaultClient{},
+				credential: &mockAzureCredential{},
+				vault:      "vault-name",
+			},
 		},
 		{
-			name: "credentials provided (vault environment variable)",
-			input: &options{
-				secrets: secrets{},
-			},
+			name:    "credentials provided (vault environment variable)",
+			input:   &Parser{},
 			options: evalClientOptions{},
 			env: map[string]string{
 				"AZURE_KEYVAULT_NAME": "vault-name",
 			},
-			want:    &mockKeyVaultClient{},
-			wantErr: nil,
-		},
-		{
-			name:    "Empty secrets",
-			input:   &options{},
-			options: evalClientOptions{},
-			env: map[string]string{
-				"AZURE_KEYVAULT_NAME": "vault-name",
+			want: &Parser{
+				client:     &mockKeyVaultClient{},
+				credential: &mockAzureCredential{},
+				vault:      "vault-name",
 			},
-			want:    &mockKeyVaultClient{},
 			wantErr: nil,
 		},
 		{
-			name:    "nil options",
+			name:    "nil parser",
 			input:   nil,
 			options: evalClientOptions{},
 			env: map[string]string{
 				"AZURE_KEYVAULT_NAME": "vault-name",
 			},
-			want:    &mockKeyVaultClient{},
-			wantErr: nil,
+			want:    nil,
+			wantErr: errors.New("a *Parser must be provided"),
 		},
 		{
 			name:    "credential error",
-			input:   &options{},
+			input:   &Parser{},
 			options: evalClientOptions{credentialErr: errors.New("error")},
 			env:     nil,
-			want:    nil,
+			want: &Parser{
+				credential: &mockAzureCredential{},
+			},
 			wantErr: errors.New("error"),
 		},
 		{
 			name:    "vault name error",
-			input:   &options{},
+			input:   &Parser{},
 			options: evalClientOptions{},
 			env:     nil,
-			want:    nil,
+			want: &Parser{
+				credential: &mockAzureCredential{},
+			},
 			wantErr: errors.New("error"),
 		},
 		{
 			name:    "secrets client error",
-			input:   &options{},
-			options: evalClientOptions{secretsClientErr: errors.New("error")},
+			input:   &Parser{},
+			options: evalClientOptions{ClientErr: errors.New("error")},
 			env: map[string]string{
 				"AZURE_KEYVAULT_NAME": "vault-name",
 			},
-			want:    &mockKeyVaultClient{},
+			want: &Parser{
+				credential: &mockAzureCredential{},
+				vault:      "vault-name",
+			},
 			wantErr: errors.New("error"),
 		},
 	}
@@ -385,14 +373,14 @@ func TestEvalClient(t *testing.T) {
 			got, gotErr := evalClient(
 				test.input,
 				func() (azcore.TokenCredential, error) {
-					return mockAzureCredential{}, test.options.credentialErr
+					return &mockAzureCredential{}, test.options.credentialErr
 				},
-				func(vault string, cred azcore.TokenCredential, options *keyvault.ClientOptions) (SecretsClient, error) {
-					return &mockKeyVaultClient{}, test.options.secretsClientErr
+				func(vault string, cred azcore.TokenCredential, options *keyvault.ClientOptions) (Client, error) {
+					return &mockKeyVaultClient{}, test.options.ClientErr
 				},
 			)
 
-			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(mockAzureCredential{}, mockKeyVaultClient{})); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmp.AllowUnexported(Parser{}, mockAzureCredential{}, mockKeyVaultClient{})); diff != "" {
 				t.Errorf("evalClient(%+v, fn, fn) = unexpected result, (-want, +got)\n%s\n", test.input, diff)
 			}
 
@@ -406,13 +394,12 @@ func TestEvalClient(t *testing.T) {
 }
 
 type evalClientOptions struct {
-	credentialErr    error
-	secretsClientErr error
+	credentialErr error
+	ClientErr     error
 }
 
 func resetOptions() {
-	pkgOpts = &options{
-		secrets:     secrets{},
+	parser = &Parser{
 		concurrency: defaultConcurrency,
 		timeout:     defaultTimeout,
 	}

--- a/parser.go
+++ b/parser.go
@@ -11,7 +11,7 @@ type Client interface {
 	GetSecrets(names []string) (map[string]string, error)
 }
 
-// Parser contains all the necessary values and settings for a Parse call.
+// Parser contains all the necessary values and settings for calls to Parse.
 type Parser struct {
 	client      Client
 	credential  azcore.TokenCredential

--- a/parser.go
+++ b/parser.go
@@ -47,7 +47,7 @@ func (p *Parser) SetClient(client Client) *Parser {
 	return p
 }
 
-// SetCredential sets credentials to be used for requests to Azure Key Vault.
+// SetCredential sets credential to be used for requests to Azure Key Vault.
 // Use when credential reuse is desirable.
 func (p *Parser) SetCredential(cred azcore.TokenCredential) *Parser {
 	p.credential = cred

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,78 @@
+package azcfg
+
+import (
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+var (
+	// defaultConcurrency contains the default concurrency for the
+	// parser.
+	defaultConcurrency = 10
+	// defaultTimeout contains the default timeout for the parser.
+	defaultTimeout = time.Millisecond * 1000 * 10
+)
+
+var (
+	// parser is the package level parser and the settings.
+	parser = Parser{
+		secrets:     secrets{},
+		concurrency: defaultConcurrency,
+		timeout:     defaultTimeout,
+	}
+)
+
+// secrets contains options for the secrets client.
+type secrets struct {
+	client     SecretsClient
+	credential azcore.TokenCredential
+	vault      string
+}
+
+// Parser ...
+type Parser struct {
+	secrets     secrets
+	timeout     time.Duration
+	concurrency int
+}
+
+// Options ...
+type Options struct {
+	SecretsClient SecretsClient
+	Credential    azcore.TokenCredential
+	Vault         string
+	Timeout       time.Duration
+	Concurrency   int
+}
+
+// NewParser creates and returns a *Parser.
+func NewParser(options ...Options) *Parser {
+	parser := &Parser{
+		timeout:     defaultTimeout,
+		concurrency: defaultConcurrency,
+	}
+	for _, o := range options {
+		if o.SecretsClient != nil {
+			parser.secrets.client = o.SecretsClient
+		}
+		if o.Credential != nil {
+			parser.secrets.credential = o.Credential
+		}
+		if len(o.Vault) != 0 {
+			parser.secrets.vault = o.Vault
+		}
+		if o.Timeout != 0 {
+			parser.timeout = o.Timeout
+		}
+		if o.Concurrency != 0 {
+			parser.concurrency = o.Concurrency
+		}
+	}
+	return parser
+}
+
+// Parse secrets from an Azure Key Vault into a struct.
+func (p Parser) Parse(v any) error {
+	return parse(v, p.secrets.client)
+}


### PR DESCRIPTION
This PR adds a new exported `Parser` type. It can be created (and configured) with the `NewParser` function. This new `Parser` replaces how the module works internally by replacing the old private `pkgOpts` for package level options. This renders some of the other types unecessary and thus, they have been removed.

Some of the public functions that set options on the package level has been renamed, these are:

- `SetSecretsClient` -> `SetClient`
- `SetAzureCredential` -> `SetCredential`
- `SetSecretVault` -> `SetVault`

The public interface `SecretsClient` have been renamed to just `Client`.