### PR TITLE
feat: client retry policy

### DIFF
--- a/internal/httpr/httpr.go
+++ b/internal/httpr/httpr.go
@@ -51,7 +51,6 @@ func NewClient(options ...Option) *Client {
 
 // Do sends an HTTP request and returns an HTTP response.
 func (c Client) Do(r *http.Request) (*http.Response, error) {
-
 	if r.Body != nil && r.GetBody == nil {
 		if err := bufferRequestBody(r); err != nil {
 			return nil, err

--- a/internal/secret/options.go
+++ b/internal/secret/options.go
@@ -1,0 +1,28 @@
+package secret
+
+import (
+	"time"
+
+	"github.com/KarlGW/azcfg/internal/httpr"
+)
+
+// WithConcurrency sets the concurrency for secret retrieval.
+func WithConcurrency(n int) ClientOption {
+	return func(c *Client) {
+		c.concurrency = n
+	}
+}
+
+// WithTimeout sets timeout for secret retreival.
+func WithTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.timeout = d
+	}
+}
+
+// WithRetryPolicy sets the retry policy for secret retrieval.
+func WithRetryPolicy(r httpr.RetryPolicy) ClientOption {
+	return func(c *Client) {
+		c.retryPolicy = r
+	}
+}

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -41,9 +41,9 @@ func (s Secret) GetValue() string {
 type Client struct {
 	c           request.Client
 	cred        auth.Credential
-	retryPolicy httpr.RetryPolicy
 	baseURL     string
 	userAgent   string
+	retryPolicy httpr.RetryPolicy
 	concurrency int
 	timeout     time.Duration
 }

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -41,6 +41,7 @@ func (s Secret) GetValue() string {
 type Client struct {
 	c           request.Client
 	cred        auth.Credential
+	retryPolicy httpr.RetryPolicy
 	baseURL     string
 	userAgent   string
 	concurrency int
@@ -65,6 +66,7 @@ func NewClient(keyVault string, cred auth.Credential, options ...ClientOption) *
 	if c.c == nil {
 		c.c = httpr.NewClient(
 			httpr.WithTimeout(c.timeout),
+			httpr.WithRetryPolicy(c.retryPolicy),
 		)
 	}
 	return c
@@ -192,18 +194,4 @@ func (c Client) getSecrets(ctx context.Context, names []string, options ...Optio
 		secrets[sr.name] = sr.secret
 	}
 	return secrets, nil
-}
-
-// WithConcurrency sets the concurrency for secret retrieval.
-func WithConcurrency(n int) ClientOption {
-	return func(c *Client) {
-		c.concurrency = n
-	}
-}
-
-// WithTimeout sets timeout for secret retreival.
-func WithTimeout(d time.Duration) ClientOption {
-	return func(c *Client) {
-		c.timeout = d
-	}
 }

--- a/internal/setting/options.go
+++ b/internal/setting/options.go
@@ -1,0 +1,35 @@
+package setting
+
+import (
+	"time"
+
+	"github.com/KarlGW/azcfg/internal/httpr"
+)
+
+// WithConcurrency sets the concurrency for setting retrieval.
+func WithConcurrency(n int) ClientOption {
+	return func(c *Client) {
+		c.concurrency = n
+	}
+}
+
+// WithTimeout sets timeout for setting retreival.
+func WithTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.timeout = d
+	}
+}
+
+// WithLabel sets label on the on a setting request.
+func WithLabel(label string) Option {
+	return func(o *Options) {
+		o.Label = label
+	}
+}
+
+// WithRetryPolicy sets the retry policy for setting retrieval.
+func WithRetryPolicy(r httpr.RetryPolicy) ClientOption {
+	return func(c *Client) {
+		c.retryPolicy = r
+	}
+}

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -42,9 +42,9 @@ func (s Setting) GetValue() string {
 type Client struct {
 	c           request.Client
 	cred        auth.Credential
-	retryPolicy httpr.RetryPolicy
 	baseURL     string
 	userAgent   string
+	retryPolicy httpr.RetryPolicy
 	concurrency int
 	timeout     time.Duration
 }

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -42,6 +42,7 @@ func (s Setting) GetValue() string {
 type Client struct {
 	c           request.Client
 	cred        auth.Credential
+	retryPolicy httpr.RetryPolicy
 	baseURL     string
 	userAgent   string
 	concurrency int
@@ -66,6 +67,7 @@ func NewClient(appConfiguration string, cred auth.Credential, options ...ClientO
 	if c.c == nil {
 		c.c = httpr.NewClient(
 			httpr.WithTimeout(c.timeout),
+			httpr.WithRetryPolicy(c.retryPolicy),
 		)
 	}
 	return c
@@ -207,25 +209,4 @@ func (c Client) getSettings(ctx context.Context, keys []string, options ...Optio
 		settings[sr.key] = sr.setting
 	}
 	return settings, nil
-}
-
-// WithConcurrency sets the concurrency for secret retrieval.
-func WithConcurrency(n int) ClientOption {
-	return func(c *Client) {
-		c.concurrency = n
-	}
-}
-
-// WithTimeout sets timeout for secret retreival.
-func WithTimeout(d time.Duration) ClientOption {
-	return func(c *Client) {
-		c.timeout = d
-	}
-}
-
-// WithLabel sets label on the on a setting request.
-func WithLabel(label string) Option {
-	return func(o *Options) {
-		o.Label = label
-	}
 }

--- a/options.go
+++ b/options.go
@@ -17,6 +17,8 @@ type Options struct {
 	SecretClient secretClient
 	// SettingClient is a client used to retrieve settings.
 	SettingClient settingClient
+	// RetryPolicy is the retry policy for the clients of the parser.
+	RetryPolicy RetryPolicy
 	// KeyVault is the name of the Key Vault containing secrets. Used to override the
 	// default method of aquiring target Key Vault.
 	KeyVault string
@@ -133,5 +135,12 @@ func WithSecretClient(c secretClient) Option {
 func WithSettingClient(c settingClient) Option {
 	return func(o *Options) {
 		o.SettingClient = c
+	}
+}
+
+// WithRetryPolicy sets the retry policy for the parser.
+func WithRetryPolicy(r RetryPolicy) Option {
+	return func(o *Options) {
+		o.RetryPolicy = r
 	}
 }

--- a/options.go
+++ b/options.go
@@ -17,8 +17,6 @@ type Options struct {
 	SecretClient secretClient
 	// SettingClient is a client used to retrieve settings.
 	SettingClient settingClient
-	// RetryPolicy is the retry policy for the clients of the parser.
-	RetryPolicy RetryPolicy
 	// KeyVault is the name of the Key Vault containing secrets. Used to override the
 	// default method of aquiring target Key Vault.
 	KeyVault string
@@ -37,6 +35,8 @@ type Options struct {
 	Certificates []*x509.Certificate
 	// PrivateKey to be used with the certificates for the Service Principal with access to target Key Vault.
 	PrivateKey *rsa.PrivateKey
+	// RetryPolicy is the retry policy for the clients of the parser.
+	RetryPolicy RetryPolicy
 	// Concurrency is the amount of secrets that will be retrieved concurrently.
 	// Defaults to 10.
 	Concurrency int

--- a/parser.go
+++ b/parser.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/KarlGW/azcfg/auth"
+	"github.com/KarlGW/azcfg/internal/httpr"
 	"github.com/KarlGW/azcfg/internal/identity"
 	"github.com/KarlGW/azcfg/internal/secret"
 	"github.com/KarlGW/azcfg/internal/setting"
@@ -51,6 +52,9 @@ type secretClient interface {
 type settingClient interface {
 	GetSettings(keys []string, options ...setting.Option) (map[string]setting.Setting, error)
 }
+
+// RetryPolicy contains rules for retries.
+type RetryPolicy = httpr.RetryPolicy
 
 // parser contains all the necessary values and settings for calls to Parse.
 type parser struct {
@@ -95,6 +99,7 @@ func NewParser(options ...Option) (*parser, error) {
 			p.cred,
 			secret.WithTimeout(p.timeout),
 			secret.WithConcurrency(p.concurrency),
+			secret.WithRetryPolicy(opts.RetryPolicy),
 		)
 	} else {
 		p.secretClient = opts.SecretClient
@@ -114,6 +119,7 @@ func NewParser(options ...Option) (*parser, error) {
 			p.cred,
 			setting.WithTimeout(p.timeout),
 			setting.WithConcurrency(p.concurrency),
+			setting.WithRetryPolicy(opts.RetryPolicy),
 		)
 	} else {
 		p.settingClient = opts.SettingClient


### PR DESCRIPTION
This pull request adds support for passing along a retry policy for the clients (secret and setting) for the parser.