### PR TITLE
feat: context option

### DIFF
--- a/azcfg.go
+++ b/azcfg.go
@@ -1,6 +1,7 @@
 package azcfg
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -24,11 +25,11 @@ func Parse(v any, options ...Option) error {
 	if err != nil {
 		return err
 	}
-	return parser.Parse(v)
+	return parser.Parse(v, options...)
 }
 
 // Parse secrets into the configuration.
-func parse(d any, secretClient secretClient, settingClient settingClient, label string) error {
+func parse(ctx context.Context, d any, secretClient secretClient, settingClient settingClient, label string) error {
 	v := reflect.ValueOf(d)
 	if v.Kind() != reflect.Pointer {
 		return errors.New("must provide a pointer to a struct")
@@ -47,7 +48,7 @@ func parse(d any, secretClient secretClient, settingClient settingClient, label 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			secrets, err := secretClient.GetSecrets(secretFields)
+			secrets, err := secretClient.GetSecrets(ctx, secretFields)
 			if err != nil {
 				errCh <- err
 				return
@@ -72,7 +73,7 @@ func parse(d any, secretClient secretClient, settingClient settingClient, label 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			settings, err := settingClient.GetSettings(settingFields, setting.WithLabel(label))
+			settings, err := settingClient.GetSettings(ctx, settingFields, setting.WithLabel(label))
 			if err != nil {
 				errCh <- err
 				return

--- a/azcfg_test.go
+++ b/azcfg_test.go
@@ -1,6 +1,7 @@
 package azcfg
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strconv"
@@ -185,7 +186,7 @@ func TestParse(t *testing.T) {
 			secretClient := mockSecretClient{err: test.wantErr}
 			settingClient := mockSettingClient{err: test.wantErr}
 
-			gotErr := parse(&test.input, secretClient, settingClient, "")
+			gotErr := parse(context.Background(), &test.input, secretClient, settingClient, "")
 			if diff := cmp.Diff(test.want, test.input, cmp.AllowUnexported(Struct{})); diff != "" {
 				t.Errorf("parse() = unexpected result, (-want, +got)\n%s\n", diff)
 			}
@@ -220,7 +221,7 @@ func TestParseRequired(t *testing.T) {
 			secretClient := mockSecretClient{}
 			settingClient := mockSettingClient{}
 
-			gotErr := parse(&test.input, secretClient, settingClient, "")
+			gotErr := parse(context.Background(), &test.input, secretClient, settingClient, "")
 			if test.wantErr != nil && gotErr == nil {
 				t.Errorf("Unexpected result, should return error\n")
 			}
@@ -394,7 +395,7 @@ type mockSecretClient struct {
 	err error
 }
 
-func (c mockSecretClient) GetSecrets(names []string, options ...secret.Option) (map[string]secret.Secret, error) {
+func (c mockSecretClient) GetSecrets(ctx context.Context, names []string, options ...secret.Option) (map[string]secret.Secret, error) {
 	if c.err != nil {
 		return nil, errors.New("could not get secrets")
 	}
@@ -426,7 +427,7 @@ type mockSettingClient struct {
 	err error
 }
 
-func (c mockSettingClient) GetSettings(keys []string, options ...setting.Option) (map[string]setting.Setting, error) {
+func (c mockSettingClient) GetSettings(ctx context.Context, keys []string, options ...setting.Option) (map[string]setting.Setting, error) {
 	time.Sleep(time.Millisecond * 10)
 	if c.err != nil {
 		return nil, errors.New("could not get settings")

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -81,10 +81,7 @@ type Options struct{}
 type Option func(o *Options)
 
 // GetSecrets gets secrets by names.
-func (c Client) GetSecrets(names []string, options ...Option) (map[string]Secret, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	defer cancel()
-
+func (c Client) GetSecrets(ctx context.Context, names []string, options ...Option) (map[string]Secret, error) {
 	return c.getSecrets(ctx, names, options...)
 }
 

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -119,7 +119,7 @@ func TestClient_GetSecrets(t *testing.T) {
 				c.timeout = time.Millisecond * 10
 			})
 
-			got, gotErr := client.GetSecrets(test.input.names)
+			got, gotErr := client.GetSecrets(context.Background(), test.input.names)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("GetSecrets() = unexpected result (-want +got)\n%s\n", diff)

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -100,10 +100,7 @@ type Options struct {
 type Option func(o *Options)
 
 // GetSettings get settings (key-values) by keys.
-func (c *Client) GetSettings(keys []string, options ...Option) (map[string]Setting, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	defer cancel()
-
+func (c *Client) GetSettings(ctx context.Context, keys []string, options ...Option) (map[string]Setting, error) {
 	return c.getSettings(ctx, keys, options...)
 }
 

--- a/internal/setting/setting_test.go
+++ b/internal/setting/setting_test.go
@@ -198,7 +198,7 @@ func TestClient_GetSettings(t *testing.T) {
 				c.timeout = time.Millisecond * 10
 			})
 
-			got, gotErr := client.GetSettings(test.input.keys, test.input.options...)
+			got, gotErr := client.GetSettings(context.Background(), test.input.keys, test.input.options...)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("GetSettings() = unexpected result (-want +got)\n%s\n", diff)

--- a/options.go
+++ b/options.go
@@ -18,6 +18,9 @@ type Options struct {
 	SecretClient secretClient
 	// SettingClient is a client used to retrieve settings.
 	SettingClient settingClient
+	// Context for the parser. By default a context is created based on the timeout set on the parser.
+	// Only applies when used together with the Parse function or parser Parse method.
+	Context context.Context
 	// KeyVault is the name of the Key Vault containing secrets. Used to override the
 	// default method of aquiring target Key Vault.
 	KeyVault string
@@ -48,8 +51,6 @@ type Options struct {
 	// UseManagedIdentity set to use a managed identity. To use a user assigned managed identity, use
 	// together with ClientID.
 	UseManagedIdentity bool
-	// Context for the parser. By default a context is created based on the timeout set on the parser.
-	Context context.Context
 }
 
 // Option is a function that sets Options.

--- a/options.go
+++ b/options.go
@@ -161,7 +161,7 @@ func WithRetryPolicy(r RetryPolicy) Option {
 	}
 }
 
-// WithContext sets the context for the parser.
+// WithContext sets the context for the call to Parse.
 func WithContext(ctx context.Context) Option {
 	return func(o *Options) {
 		o.Context = ctx

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package azcfg
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"time"
@@ -47,6 +48,8 @@ type Options struct {
 	// UseManagedIdentity set to use a managed identity. To use a user assigned managed identity, use
 	// together with ClientID.
 	UseManagedIdentity bool
+	// Context for the parser. By default a context is created based on the timeout set on the parser.
+	Context context.Context
 }
 
 // Option is a function that sets Options.
@@ -154,5 +157,12 @@ func WithSettingClient(c settingClient) Option {
 func WithRetryPolicy(r RetryPolicy) Option {
 	return func(o *Options) {
 		o.RetryPolicy = r
+	}
+}
+
+// WithContext sets the context for the parser.
+func WithContext(ctx context.Context) Option {
+	return func(o *Options) {
+		o.Context = ctx
 	}
 }

--- a/options.go
+++ b/options.go
@@ -18,7 +18,7 @@ type Options struct {
 	SecretClient secretClient
 	// SettingClient is a client used to retrieve settings.
 	SettingClient settingClient
-	// Context for the parser. By default a context is created based on the timeout set on the parser.
+	// Context for parsing. By default a context is created based on the timeout set on the parser.
 	// Only applies when used together with the Parse function or parser Parse method.
 	Context context.Context
 	// KeyVault is the name of the Key Vault containing secrets. Used to override the

--- a/parser.go
+++ b/parser.go
@@ -130,6 +130,9 @@ func NewParser(options ...Option) (*parser, error) {
 }
 
 // Parse secrets from an Azure Key Vault into a struct.
+//
+// The only valid option is context, the other options on the
+// parser remain unaffected.
 func (p *parser) Parse(v any, options ...Option) error {
 	opts := Options{}
 	for _, option := range options {

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package azcfg
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -45,12 +46,12 @@ const (
 
 // secretClient is the interface that wraps around method GetSecrets.
 type secretClient interface {
-	GetSecrets(names []string, options ...secret.Option) (map[string]secret.Secret, error)
+	GetSecrets(ctx context.Context, names []string, options ...secret.Option) (map[string]secret.Secret, error)
 }
 
 // settingClient is the interface that wraps around method GetSettings.
 type settingClient interface {
-	GetSettings(keys []string, options ...setting.Option) (map[string]setting.Setting, error)
+	GetSettings(ctx context.Context, keys []string, options ...setting.Option) (map[string]setting.Setting, error)
 }
 
 // RetryPolicy contains rules for retries.
@@ -129,8 +130,22 @@ func NewParser(options ...Option) (*parser, error) {
 }
 
 // Parse secrets from an Azure Key Vault into a struct.
-func (p *parser) Parse(v any) error {
-	return parse(v, p.secretClient, p.settingClient, p.label)
+func (p *parser) Parse(v any, options ...Option) error {
+	opts := Options{}
+	for _, option := range options {
+		option(&opts)
+	}
+
+	var ctx context.Context
+	if opts.Context == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), p.timeout)
+		defer cancel()
+	} else {
+		ctx = opts.Context
+	}
+
+	return parse(ctx, v, p.secretClient, p.settingClient, p.label)
 }
 
 // setupCredential configures credential based on the provided

--- a/stub/stub.go
+++ b/stub/stub.go
@@ -1,6 +1,8 @@
 package stub
 
 import (
+	"context"
+
 	"github.com/KarlGW/azcfg/internal/secret"
 	"github.com/KarlGW/azcfg/internal/setting"
 )
@@ -29,7 +31,7 @@ func NewSecretClient(secrets map[string]string, err error) SecretClient {
 }
 
 // Get secrets set to the stub client.
-func (c SecretClient) GetSecrets(names []string, options ...secret.Option) (map[string]secret.Secret, error) {
+func (c SecretClient) GetSecrets(ctx context.Context, names []string, options ...secret.Option) (map[string]secret.Secret, error) {
 	if c.err != nil {
 		return nil, c.err
 	}
@@ -60,7 +62,7 @@ func NewSettingClient(settings map[string]string, err error) SettingClient {
 }
 
 // Get settings set to the stub client.
-func (c SettingClient) GetSettings(keys []string, options ...setting.Option) (map[string]setting.Setting, error) {
+func (c SettingClient) GetSettings(ctx context.Context, keys []string, options ...setting.Option) (map[string]setting.Setting, error) {
 	if c.err != nil {
 		return nil, c.err
 	}

--- a/stub/stub_test.go
+++ b/stub/stub_test.go
@@ -1,6 +1,7 @@
 package stub
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestSecretClient_GetSecrets(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cl := NewSecretClient(test.input.secrets, test.input.err)
-			got, gotErr := cl.GetSecrets(test.input.names)
+			got, gotErr := cl.GetSecrets(context.Background(), test.input.names)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("GetSecrets() = unexpected result (-want +got)\n%s\n", diff)
@@ -161,7 +162,7 @@ func TestSettingClient_GetSettings(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cl := NewSettingClient(test.input.settings, test.input.err)
-			got, gotErr := cl.GetSettings(test.input.keys)
+			got, gotErr := cl.GetSettings(context.Background(), test.input.keys)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("GetSettings() = unexpected result (-want +got)\n%s\n", diff)


### PR DESCRIPTION
The inner clients methods for retrieving secrets and setts have been updated to take a provided context. To address this, the context is created in parsers method `Parse`.  Options have been updated with `Context`. This context is not set on the parser itself, and only applies when using the `Parse` method or the package function `Parse`.