### PR TITLE
feat: handling of unset key vault and app configuration name

### DIFF
--- a/azcfg.go
+++ b/azcfg.go
@@ -56,7 +56,10 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 	var wg sync.WaitGroup
 
 	secretFields, requiredSecrets := getFields(v, secretTag)
-	if len(secretFields) > 0 && secretClient != nil {
+	if len(secretFields) > 0 {
+		if secretClient == nil {
+			return fmt.Errorf("%w: no key vault name set", ErrSecretClient)
+		}
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -81,7 +84,11 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 	}
 
 	settingFields, requiredSettings := getFields(v, settingTag)
-	if len(settingFields) > 0 && settingClient != nil {
+	if len(settingFields) > 0 {
+		if settingClient == nil {
+			return fmt.Errorf("%w: no app configuration name set", ErrSettingClient)
+		}
+
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
This pull request makes a change to the behaviour of parsing when key vault or app configuration name is not set.

- If struct tags for secrets is set, but no key vault name can be found it will return an error.
- If struct tags for settings is set, but no app config name can be found it will return an error.