### PR TITLE
feat: arguments and options

### DIFF
--- a/azcfg.go
+++ b/azcfg.go
@@ -67,6 +67,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 				return
 			}
 			secretsCh <- secrets
+			close(secretsCh)
 		}()
 	}
 
@@ -87,6 +88,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 				return
 			}
 			settingsCh <- settings
+			close(settingsCh)
 		}()
 	}
 
@@ -95,8 +97,6 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 		done <- struct{}{}
 		close(done)
 		close(errCh)
-		close(secretsCh)
-		close(settingsCh)
 	}()
 
 	var errs []error

--- a/azcfg.go
+++ b/azcfg.go
@@ -158,7 +158,6 @@ type hasValue interface {
 	GetValue() string
 }
 
-// setFields sets the values from the incoming map to the struct fields.
 func setFields[V hasValue](v reflect.Value, values map[string]V, tag string) error {
 	t := v.Type()
 	for i := 0; i < v.NumField(); i++ {

--- a/azcfg.go
+++ b/azcfg.go
@@ -158,6 +158,7 @@ type hasValue interface {
 	GetValue() string
 }
 
+// setFields sets the values from the incoming map to the struct fields.
 func setFields[V hasValue](v reflect.Value, values map[string]V, tag string) error {
 	t := v.Type()
 	for i := 0; i < v.NumField(); i++ {

--- a/azcfg.go
+++ b/azcfg.go
@@ -31,8 +31,6 @@ func Parse(ctx context.Context, v any, options ...Option) error {
 type parseOptions struct {
 	secretClient  secretClient
 	settingClient settingClient
-	labels        map[string]string
-	label         string
 }
 
 // Parse secrets into the configuration.
@@ -58,6 +56,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 		if secretClient == nil {
 			return fmt.Errorf("%w: key vault name not set", ErrSecretClient)
 		}
+
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/azcfg.go
+++ b/azcfg.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/KarlGW/azcfg/internal/setting"
 )
 
 const (
@@ -21,12 +19,12 @@ const (
 
 // Parse secrets from an Azure Key Vault and settings from an
 // Azure App Configuration into the provided struct.
-func Parse(v any, options ...Option) error {
+func Parse(ctx context.Context, v any, options ...Option) error {
 	parser, err := NewParser(options...)
 	if err != nil {
 		return err
 	}
-	return parser.Parse(v, options...)
+	return parser.Parse(ctx, v)
 }
 
 // parseOptions contains options for the parser.
@@ -92,7 +90,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			settings, err := settingClient.GetSettings(ctx, settingFields, setting.WithLabel(opts.label), setting.WithLabels(opts.labels))
+			settings, err := settingClient.GetSettings(ctx, settingFields)
 			if err != nil {
 				errCh <- fmt.Errorf("%w: %s", ErrSettingRetrieval, err.Error())
 				return

--- a/internal/identity/azure_cli_credential.go
+++ b/internal/identity/azure_cli_credential.go
@@ -49,7 +49,7 @@ func (c *AzureCLICredential) Token(ctx context.Context, options ...auth.TokenOpt
 		return *c.tokens[opts.Scope], nil
 	}
 
-	token, err := cliToken(ctx, opts.Scope)
+	token, err := cliToken(opts.Scope)
 	if err != nil {
 		return auth.Token{}, err
 	}
@@ -59,7 +59,7 @@ func (c *AzureCLICredential) Token(ctx context.Context, options ...auth.TokenOpt
 }
 
 // cliToken retreives a token from the Azure CLI.
-var cliToken = func(ctx context.Context, scope string) (auth.Token, error) {
+var cliToken = func(scope string) (auth.Token, error) {
 	var command, flag, dir string
 	if runtime.GOOS == "windows" {
 		dir = os.Getenv("SYSTEMROOT")
@@ -72,7 +72,7 @@ var cliToken = func(ctx context.Context, scope string) (auth.Token, error) {
 	}
 
 	arguments := "az account get-access-token --output json --resource " + strings.TrimSuffix(scope, "/.default")
-	cmd := exec.CommandContext(ctx, command, flag, arguments)
+	cmd := exec.Command(command, flag, arguments)
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
 

--- a/internal/identity/azure_cli_credential_test.go
+++ b/internal/identity/azure_cli_credential_test.go
@@ -112,7 +112,7 @@ func TestAzureCLICredential_Token(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cliToken = func(ctx context.Context, _ string) (auth.Token, error) {
+			cliToken = func(_ string) (auth.Token, error) {
 				if test.wantErr != nil {
 					return auth.Token{}, test.wantErr
 				}

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -202,6 +202,7 @@ func (c Client) getSecrets(ctx context.Context, names []string, options ...Optio
 					sr.secret = secret
 					srCh <- sr
 				case <-ctx.Done():
+					srCh <- secretResult{err: ctx.Err()}
 					return
 				}
 			}

--- a/internal/setting/options.go
+++ b/internal/setting/options.go
@@ -39,7 +39,23 @@ func WithCloud(c cloud.Cloud) ClientOption {
 	}
 }
 
-// WithLabel sets label on the on a setting request.
+// WithClientLabel sets label on the setting client.
+func WithClientLabel(label string) ClientOption {
+	return func(c *Client) {
+		c.label = label
+	}
+}
+
+// WithClientLabels sets labels on the setting client based on the provided
+// map. The key of the map should be the setting name, and the value
+// should be the label.
+func WithClientLabels(labels map[string]string) ClientOption {
+	return func(c *Client) {
+		c.labels = labels
+	}
+}
+
+// WithLabel sets label on the setting request. Overrides the client label.
 func WithLabel(label string) Option {
 	return func(o *Options) {
 		o.Label = label
@@ -48,7 +64,7 @@ func WithLabel(label string) Option {
 
 // WithLabels sets labels on the setting requests based on the provided
 // map. The key of the map should be the setting name, and the value
-// should be the label.
+// should be the label. Overrides the client labels.
 func WithLabels(labels map[string]string) Option {
 	return func(o *Options) {
 		o.Labels = labels

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -74,6 +74,8 @@ type Client struct {
 	scope       string
 	baseURL     string
 	userAgent   string
+	label       string
+	labels      map[string]string
 	retryPolicy httpr.RetryPolicy
 	concurrency int
 	timeout     time.Duration
@@ -173,7 +175,10 @@ func (c *Client) GetSettings(ctx context.Context, keys []string, options ...Opti
 
 // Get a setting.
 func (c *Client) Get(ctx context.Context, key string, options ...Option) (Setting, error) {
-	opts := Options{}
+	opts := Options{
+		Label:  c.label,
+		Labels: c.labels,
+	}
 	for _, option := range options {
 		option(&opts)
 	}
@@ -345,6 +350,7 @@ func (c *Client) getSettings(ctx context.Context, keys []string, options ...Opti
 					sr.setting = setting
 					srCh <- sr
 				case <-ctx.Done():
+					srCh <- settingResult{err: ctx.Err()}
 					return
 				}
 			}

--- a/internal/setting/setting_test.go
+++ b/internal/setting/setting_test.go
@@ -177,6 +177,7 @@ func TestClient_GetSettings(t *testing.T) {
 			label         string
 			labels        map[string]string
 			secrets       map[string]Secret
+			timeout       time.Duration
 			err           error
 		}
 		want    map[string]Setting
@@ -192,6 +193,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -200,6 +202,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -218,6 +221,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				withAccessKey: true,
@@ -227,6 +231,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -245,6 +250,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -257,6 +263,7 @@ func TestClient_GetSettings(t *testing.T) {
 				options: []Option{
 					WithLabel("prod"),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -275,6 +282,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -293,6 +301,7 @@ func TestClient_GetSettings(t *testing.T) {
 						"setting-c": "test",
 					}),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -311,6 +320,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -322,6 +332,7 @@ func TestClient_GetSettings(t *testing.T) {
 				secrets: map[string]Secret{
 					"secret-1": {Value: "1"},
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {ContentType: keyVaultReferenceContentType, Value: "1"},
@@ -340,6 +351,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -347,6 +359,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-a": []byte(`{"value":"a"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -354,6 +367,29 @@ func TestClient_GetSettings(t *testing.T) {
 				"setting-c": {Value: "c"},
 			},
 			wantErr: nil,
+		},
+		{
+			name: "get settings - context deadline exceeded",
+			input: struct {
+				withAccessKey bool
+				keys          []string
+				options       []Option
+				bodies        map[string][]byte
+				label         string
+				labels        map[string]string
+				secrets       map[string]Secret
+				timeout       time.Duration
+				err           error
+			}{
+				keys: []string{"setting-a", "setting-b", "setting-c"},
+				bodies: map[string][]byte{
+					"setting-a": []byte(`{"value":"a"}`),
+					"setting-b": []byte(`{"value":"b"}`),
+					"setting-c": []byte(`{"value":"c"}`),
+				},
+				timeout: time.Nanosecond,
+			},
+			wantErr: cmpopts.AnyError,
 		},
 		{
 			name: "setting forbidden",
@@ -365,10 +401,12 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
-				keys: []string{"setting-a"},
-				err:  errForbidden,
+				keys:    []string{"setting-a"},
+				timeout: 30 * time.Millisecond,
+				err:     errForbidden,
 			},
 			wantErr: settingError{
 				StatusCode: http.StatusForbidden,
@@ -385,6 +423,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -393,6 +432,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
+				timeout: 30 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {ContentType: keyVaultReferenceContentType, Value: ""},
@@ -411,10 +451,12 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
-				keys: []string{"setting-a"},
-				err:  errServer,
+				keys:    []string{"setting-a"},
+				timeout: 30 * time.Millisecond,
+				err:     errServer,
 			},
 			want: nil,
 			wantErr: settingError{
@@ -433,10 +475,12 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
-				keys: []string{"setting-a"},
-				err:  errRequest,
+				keys:    []string{"setting-a"},
+				timeout: 30 * time.Millisecond,
+				err:     errRequest,
 			},
 			want:    nil,
 			wantErr: errRequest,
@@ -451,6 +495,7 @@ func TestClient_GetSettings(t *testing.T) {
 				label         string
 				labels        map[string]string
 				secrets       map[string]Secret
+				timeout       time.Duration
 				err           error
 			}{
 				keys: []string{"setting-a", "setting-b", "setting-c"},
@@ -460,7 +505,8 @@ func TestClient_GetSettings(t *testing.T) {
 				secrets: map[string]Secret{
 					"secret-1": {Value: "1"},
 				},
-				err: errGetSecret,
+				timeout: 30 * time.Millisecond,
+				err:     errGetSecret,
 			},
 			wantErr: errGetSecret,
 		},
@@ -490,7 +536,10 @@ func TestClient_GetSettings(t *testing.T) {
 				client, _ = NewClientWithAccessKey("config", AccessKey{ID: "id", Secret: base64.StdEncoding.EncodeToString([]byte(`secret`))}, opts...)
 			}
 
-			got, gotErr := client.GetSettings(context.Background(), test.input.keys, test.input.options...)
+			ctx, cancel := context.WithTimeout(context.Background(), test.input.timeout)
+			defer cancel()
+
+			got, gotErr := client.GetSettings(ctx, test.input.keys, test.input.options...)
 
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("GetSettings() = unexpected result (-want +got)\n%s\n", diff)
@@ -879,6 +928,7 @@ type mockHttpClient struct {
 }
 
 func (c mockHttpClient) Do(req *http.Request) (*http.Response, error) {
+	time.Sleep(10 * time.Millisecond)
 	if c.err != nil && !errors.Is(c.err, errGetSecret) {
 		if errors.Is(c.err, errServer) {
 			return &http.Response{

--- a/options.go
+++ b/options.go
@@ -1,7 +1,6 @@
 package azcfg
 
 import (
-	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"os"
@@ -72,10 +71,6 @@ type Options struct {
 	SecretClient secretClient
 	// SettingClient is a client used to retrieve settings.
 	SettingClient settingClient
-	// Context for parsing. By default a context is created based on
-	// the timeout set on the parser. Only applies when used together
-	// with the Parse function or parser Parse method.
-	Context context.Context
 	// Cloud is the Azure cloud to make requests to. Defaults to AzurePublic.
 	Cloud cloud.Cloud
 	// KeyVault is the name of the Key Vault containing secrets.
@@ -349,12 +344,5 @@ func WithCloud(c cloud.Cloud) Option {
 func WithRetryPolicy(r RetryPolicy) Option {
 	return func(o *Options) {
 		o.RetryPolicy = r
-	}
-}
-
-// WithContext sets the context for the call to Parse.
-func WithContext(ctx context.Context) Option {
-	return func(o *Options) {
-		o.Context = ctx
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -110,6 +110,8 @@ func NewParser(options ...Option) (*parser, error) {
 			setting.WithConcurrency(concurrency),
 			setting.WithRetryPolicy(opts.RetryPolicy),
 			setting.WithCloud(opts.Cloud),
+			setting.WithClientLabel(opts.Label),
+			setting.WithClientLabels(opts.Labels),
 		}
 
 		settingClient, err = newSettingClient(
@@ -140,26 +142,10 @@ func NewParser(options ...Option) (*parser, error) {
 //
 // The only valid option is context, the other options on the
 // parser remain unaffected.
-func (p *parser) Parse(v any, options ...Option) error {
-	opts := Options{}
-	for _, option := range options {
-		option(&opts)
-	}
-
-	var ctx context.Context
-	if opts.Context == nil {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), p.timeout)
-		defer cancel()
-	} else {
-		ctx = opts.Context
-	}
-
+func (p *parser) Parse(ctx context.Context, v any) error {
 	return parse(ctx, v, parseOptions{
 		secretClient:  p.secretClient,
 		settingClient: p.settingClient,
-		label:         coalesceString(opts.Label, os.Getenv(azcfgAppConfigurationLabel)),
-		labels:        coalesceMap(opts.Labels, parseLabels(os.Getenv(azcfgAppConfigurationLabels))),
 	})
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -320,32 +320,6 @@ func TestParser_Parse(t *testing.T) {
 				StringSetting: "new string setting",
 			},
 		},
-		{
-			name: "parse secrets and settings with context",
-			input: struct {
-				s          Struct
-				options    []Option
-				secrets    map[string]Secret
-				secretErr  error
-				settings   map[string]Setting
-				settingErr error
-			}{
-				s: Struct{},
-				secrets: map[string]Secret{
-					"string": {Value: "new string"},
-				},
-				settings: map[string]Setting{
-					"string-setting": {Value: "new string setting"},
-				},
-				options: []Option{
-					WithContext(context.Background()),
-				},
-			},
-			want: Struct{
-				String:        "new string",
-				StringSetting: "new string setting",
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -355,7 +329,7 @@ func TestParser_Parse(t *testing.T) {
 				settingClient: newMockSettingClient(test.input.settings, test.input.settingErr),
 			}
 
-			gotErr := p.Parse(&test.input.s, test.input.options...)
+			gotErr := p.Parse(context.Background(), &test.input.s)
 
 			if diff := cmp.Diff(test.want, test.input.s, cmp.AllowUnexported(Struct{})); diff != "" {
 				t.Errorf("Parse() = unexpected result (-want +got)\n%s\n", diff)


### PR DESCRIPTION
This pull request updates `Parse` and `parser.Parse` to take a `context.Context` as the first parameter. This to to adhere to common Go standards. The option `WithContext` has been removed.