### PR TITLE
fix: default timeouts

### DIFF
--- a/authopts/authopts_test.go
+++ b/authopts/authopts_test.go
@@ -82,7 +82,7 @@ func TestCredential_Token(t *testing.T) {
 					tokens: map[string]*auth.Token{
 						_testScope: {
 							AccessToken: "ey54321",
-							ExpiresOn:   time.Now().Add(time.Hour * -3),
+							ExpiresOn:   time.Now().Add(-3 * time.Hour),
 						},
 					},
 				}

--- a/azcfg.go
+++ b/azcfg.go
@@ -102,8 +102,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 	var errs []error
 	for {
 		select {
-		case s := <-secretsCh:
-			secrets := s
+		case secrets := <-secretsCh:
 			if len(secrets) > 0 {
 				if err := setFields(v, secrets, secretTag); err != nil {
 					if errors.Is(err, errRequired) {
@@ -112,8 +111,7 @@ func parse(ctx context.Context, d any, opts parseOptions) error {
 					errs = append(errs, err)
 				}
 			}
-		case s := <-settingsCh:
-			settings := s
+		case settings := <-settingsCh:
 			if len(settings) > 0 {
 				if err := setFields(v, settings, settingTag); err != nil {
 					if errors.Is(err, errRequired) {

--- a/azcfg_test.go
+++ b/azcfg_test.go
@@ -31,8 +31,8 @@ func TestParse(t *testing.T) {
 				BoolPtr:          toPtr(false),
 				BoolSetting:      false,
 				BoolSettingPtr:   toPtr(false),
-				Duration:         time.Second * 3,
-				DurationPtr:      toPtr(time.Second * 3),
+				Duration:         3 * time.Second,
+				DurationPtr:      toPtr(3 * time.Second),
 				Empty:            "",
 				EmptySetting:     "",
 				NestedStructA: NestedStructA{
@@ -69,8 +69,8 @@ func TestParse(t *testing.T) {
 				BoolSettingPtr:   toPtr(true),
 				StringSetting:    "new string setting",
 				StringSettingPtr: toPtr("new string setting ptr"),
-				Duration:         time.Second * 1,
-				DurationPtr:      toPtr(time.Second * 2),
+				Duration:         1 * time.Second,
+				DurationPtr:      toPtr(2 * time.Second),
 				Complex64:        5 + 12i,
 				Complex64Ptr:     toPtr[complex64](5 + 12i),
 				Complex128:       5 + 12i,
@@ -439,7 +439,7 @@ func newMockSettingClient(settings map[string]Setting, err error) mockSettingCli
 }
 
 func (c mockSettingClient) GetSettings(ctx context.Context, keys []string, options ...setting.Option) (map[string]Setting, error) {
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(30 * time.Millisecond)
 	if c.err != nil {
 		return nil, errors.New("could not get settings")
 	}

--- a/internal/httpr/httpr.go
+++ b/internal/httpr/httpr.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// defaultTimeout contains the default timeout of a *Client.
-	defaultTimeout = time.Second * 30
+	defaultTimeout = 30 * time.Second
 )
 
 // Client wraps around a standard library *http.Client with

--- a/internal/httpr/httpr_test.go
+++ b/internal/httpr/httpr_test.go
@@ -43,8 +43,8 @@ func TestClient_Do(t *testing.T) {
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay: time.Millisecond * 1,
-					MaxDelay: time.Millisecond * 5,
+					MinDelay: 1 * time.Millisecond,
+					MaxDelay: 5 * time.Millisecond,
 					Retry:    defaultRetry,
 					Backoff:  exponentialBackoff,
 				},
@@ -76,8 +76,8 @@ func TestClient_Do(t *testing.T) {
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay:   time.Millisecond * 1,
-					MaxDelay:   time.Millisecond * 5,
+					MinDelay:   1 * time.Millisecond,
+					MaxDelay:   5 * time.Millisecond,
 					Retry:      defaultRetry,
 					Backoff:    exponentialBackoff,
 					MaxRetries: 3,
@@ -98,8 +98,8 @@ func TestClient_Do(t *testing.T) {
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay:   time.Millisecond * 1,
-					MaxDelay:   time.Millisecond * 5,
+					MinDelay:   1 * time.Millisecond,
+					MaxDelay:   5 * time.Millisecond,
 					Retry:      defaultRetry,
 					Backoff:    exponentialBackoff,
 					MaxRetries: 3,
@@ -116,14 +116,14 @@ func TestClient_Do(t *testing.T) {
 			name: "successful GET - context exceeded",
 			input: input{
 				req: func() *http.Request {
-					ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*1)
+					ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 					defer cancel()
 					req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.com", nil)
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay:   time.Millisecond * 5,
-					MaxDelay:   time.Millisecond * 10,
+					MinDelay:   5 * time.Millisecond,
+					MaxDelay:   10 * time.Millisecond,
 					Retry:      defaultRetry,
 					Backoff:    exponentialBackoff,
 					MaxRetries: 3,
@@ -145,8 +145,8 @@ func TestClient_Do(t *testing.T) {
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay: time.Millisecond * 1,
-					MaxDelay: time.Millisecond * 5,
+					MinDelay: 1 * time.Millisecond,
+					MaxDelay: 5 * time.Millisecond,
 					Retry:    defaultRetry,
 					Backoff:  exponentialBackoff,
 				},
@@ -164,8 +164,8 @@ func TestClient_Do(t *testing.T) {
 					return req
 				},
 				retryPolicy: RetryPolicy{
-					MinDelay:   time.Millisecond * 1,
-					MaxDelay:   time.Millisecond * 5,
+					MinDelay:   1 * time.Millisecond,
+					MaxDelay:   5 * time.Millisecond,
 					Retry:      defaultRetry,
 					Backoff:    exponentialBackoff,
 					MaxRetries: 3,
@@ -255,7 +255,7 @@ func setupClient(target string, rp RetryPolicy, emptyClient bool, err error) *Cl
 	if emptyClient {
 		return &Client{cl: &http.Client{Transport: tr}}
 	} else {
-		return NewClient(WithTransport(tr), WithRetryPolicy(rp), WithTimeout(time.Millisecond*20))
+		return NewClient(WithTransport(tr), WithRetryPolicy(rp), WithTimeout(20*time.Millisecond))
 	}
 
 }

--- a/internal/httpr/policy.go
+++ b/internal/httpr/policy.go
@@ -56,8 +56,8 @@ func exponentialBackoff(delay, maxDelay time.Duration, retry int) time.Duration 
 // defaultRetryPolicy creates and returns a default policy.
 func defaultRetryPolicy() RetryPolicy {
 	return RetryPolicy{
-		MinDelay:   time.Millisecond * 500,
-		MaxDelay:   time.Second * 5,
+		MinDelay:   500 * time.Millisecond,
+		MaxDelay:   5 * time.Second,
 		MaxRetries: 3,
 		Retry:      defaultRetry,
 		Backoff:    exponentialBackoff,

--- a/internal/identity/azure_cli_credential_test.go
+++ b/internal/identity/azure_cli_credential_test.go
@@ -87,7 +87,7 @@ func TestAzureCLICredential_Token(t *testing.T) {
 				cred, _ := NewAzureCLICredential()
 				cred.tokens[_testScope] = &auth.Token{
 					AccessToken: "ey54321",
-					ExpiresOn:   time.Now().Add(time.Hour * -3),
+					ExpiresOn:   time.Now().Add(-3 * time.Hour),
 				}
 				return cred
 			},

--- a/internal/identity/client_assertion.go
+++ b/internal/identity/client_assertion.go
@@ -32,7 +32,7 @@ func newCertificateAssertion(endpoint, clientID string, cert certificate) (jwt, 
 
 	claims := claims{
 		AUD: endpoint,
-		EXP: time.Now().Add(time.Minute * 5).Unix(),
+		EXP: time.Now().Add(5 * time.Minute).Unix(),
 		ISS: clientID,
 		JTI: uuid,
 		NBF: time.Now().Unix(),

--- a/internal/identity/client_credential_test.go
+++ b/internal/identity/client_credential_test.go
@@ -387,7 +387,7 @@ func TestClientCredential_Token(t *testing.T) {
 				cred, _ := NewClientCredential(_testTenantID, _testClientID, WithSecret("1234"), WithHTTPClient(client))
 				cred.tokens[_testScope] = &auth.Token{
 					AccessToken: "ey54321",
-					ExpiresOn:   time.Now().Add(time.Hour * -3),
+					ExpiresOn:   time.Now().Add(-3 * time.Hour),
 				}
 				return cred
 			},

--- a/internal/identity/credential_test.go
+++ b/internal/identity/credential_test.go
@@ -48,7 +48,7 @@ func TestTokenFromAuthResult(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := tokenFromAuthResult(test.input)
 
-			if diff := cmp.Diff(test.want, got, cmpopts.EquateApproxTime(time.Second*5)); diff != "" {
+			if diff := cmp.Diff(test.want, got, cmpopts.EquateApproxTime(5*time.Second)); diff != "" {
 				t.Errorf("tokenFromAuthResult() = unexpected result (-want +got)\n%s\n", diff)
 			}
 		})

--- a/internal/identity/managed_identity_credential.go
+++ b/internal/identity/managed_identity_credential.go
@@ -184,7 +184,7 @@ func (c *ManagedIdentityCredential) tokenRequest(ctx context.Context, scope stri
 // testIMDSConnection tests the connection to the IMDS endpoint.
 func testIMDSConnection(timeout time.Duration) bool {
 	if timeout == 0 {
-		timeout = time.Second * 3
+		timeout = 3 * time.Second
 	}
 	conn, err := net.DialTimeout("tcp", "169.254.169.254:80", timeout)
 	if err != nil {

--- a/internal/identity/managed_identity_credential_test.go
+++ b/internal/identity/managed_identity_credential_test.go
@@ -260,7 +260,7 @@ func TestManagedIdentityCredential_Token(t *testing.T) {
 					cred, _ := NewManagedIdentityCredential(WithHTTPClient(client))
 					cred.tokens[_testScope] = &auth.Token{
 						AccessToken: "ey54321",
-						ExpiresOn:   time.Now().Add(time.Hour * -3),
+						ExpiresOn:   time.Now().Add(-3 * time.Hour),
 					}
 					return cred
 				},

--- a/internal/identity/options_test.go
+++ b/internal/identity/options_test.go
@@ -75,9 +75,9 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name:  "WithIMDSDialTimeout",
-			input: WithIMDSDialTimeout(time.Second * 5),
+			input: WithIMDSDialTimeout(5 * time.Second),
 			want: CredentialOptions{
-				dialTimeout: time.Second * 5,
+				dialTimeout: 5 * time.Second,
 			},
 		},
 	}

--- a/internal/secret/options_test.go
+++ b/internal/secret/options_test.go
@@ -24,9 +24,9 @@ func TestClientOptions(t *testing.T) {
 		},
 		{
 			name:  "WithTimeout",
-			input: WithTimeout(time.Second * 5),
+			input: WithTimeout(5 * time.Second),
 			want: &Client{
-				timeout: time.Second * 5,
+				timeout: 5 * time.Second,
 			},
 		},
 		{

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -23,7 +23,7 @@ const (
 	// defaultConcurrency is the default concurrency set on the client.
 	defaultConcurrency = 10
 	// defaultTimeout is the default timeout set on the client.
-	defaultTimeout = time.Second * 10
+	defaultTimeout = 30 * time.Second
 )
 
 // Secret represents a secret as returned from the Key Vault REST API.

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -137,7 +137,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					"secret-b": []byte(`{"value":"b"}`),
 					"secret-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 1 * time.Nanosecond,
+				timeout: time.Millisecond,
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -188,7 +188,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					bodies: test.input.bodies,
 					err:    test.input.err,
 				}
-				c.timeout = time.Millisecond * 10
+				c.timeout = 10 * time.Millisecond
 			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), test.input.timeout)

--- a/internal/secret/secret_test.go
+++ b/internal/secret/secret_test.go
@@ -92,7 +92,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					"secret-b": []byte(`{"value":"b"}`),
 					"secret-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Secret{
 				"secret-a": {Value: "a"},
@@ -114,7 +114,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					"secret-a": []byte(`{"value":"a"}`),
 					"secret-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Secret{
 				"secret-a": {Value: "a"},
@@ -137,7 +137,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					"secret-b": []byte(`{"value":"b"}`),
 					"secret-c": []byte(`{"value":"c"}`),
 				},
-				timeout: time.Millisecond,
+				timeout: time.Nanosecond,
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -150,7 +150,7 @@ func TestClient_GetSecrets(t *testing.T) {
 				err     error
 			}{
 				names:   []string{"secret-a"},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errServer,
 			},
 			want: nil,
@@ -173,7 +173,7 @@ func TestClient_GetSecrets(t *testing.T) {
 				err     error
 			}{
 				names:   []string{"secret-a"},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errRequest,
 			},
 			want:    nil,
@@ -188,7 +188,7 @@ func TestClient_GetSecrets(t *testing.T) {
 					bodies: test.input.bodies,
 					err:    test.input.err,
 				}
-				c.timeout = 10 * time.Millisecond
+				c.timeout = 100 * time.Millisecond
 			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), test.input.timeout)

--- a/internal/setting/auth_test.go
+++ b/internal/setting/auth_test.go
@@ -60,7 +60,7 @@ func TestHMACAuthenticationHeaders(t *testing.T) {
 				t.Errorf("hmacAuthenticationHeaders() = unexpected result (-want +got)\n%s\n", diff)
 			}
 
-			if diff := cmp.Diff(test.wantErr, gotErr, cmpopts.EquateErrors(), cmpopts.EquateApproxTime(time.Second*5)); diff != "" {
+			if diff := cmp.Diff(test.wantErr, gotErr, cmpopts.EquateErrors(), cmpopts.EquateApproxTime(5*time.Second)); diff != "" {
 				t.Errorf("hmacAuthenticationHeaders() = unexpected error (-want +got)\n%s\n", diff)
 			}
 		})

--- a/internal/setting/options_test.go
+++ b/internal/setting/options_test.go
@@ -25,9 +25,9 @@ func TestClientOptions(t *testing.T) {
 		},
 		{
 			name:  "WithTimeout",
-			input: WithTimeout(time.Second * 5),
+			input: WithTimeout(5 * time.Second),
 			want: &Client{
-				timeout: time.Second * 5,
+				timeout: 5 * time.Second,
 			},
 		},
 		{

--- a/internal/setting/setting.go
+++ b/internal/setting/setting.go
@@ -25,7 +25,7 @@ const (
 	// defaultConcurrency is the default concurrency set on the client.
 	defaultConcurrency = 10
 	// defaultTimeout is the default timeout set on the client.
-	defaultTimeout = time.Second * 10
+	defaultTimeout = 30 * time.Second
 )
 
 const (

--- a/internal/setting/setting_test.go
+++ b/internal/setting/setting_test.go
@@ -202,7 +202,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -231,7 +231,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -263,7 +263,7 @@ func TestClient_GetSettings(t *testing.T) {
 				options: []Option{
 					WithLabel("prod"),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -301,7 +301,7 @@ func TestClient_GetSettings(t *testing.T) {
 						"setting-c": "test",
 					}),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -332,7 +332,7 @@ func TestClient_GetSettings(t *testing.T) {
 				secrets: map[string]Secret{
 					"secret-1": {Value: "1"},
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {ContentType: keyVaultReferenceContentType, Value: "1"},
@@ -359,7 +359,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-a": []byte(`{"value":"a"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {Value: "a"},
@@ -387,7 +387,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: time.Millisecond,
+				timeout: time.Nanosecond,
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -405,7 +405,7 @@ func TestClient_GetSettings(t *testing.T) {
 				err           error
 			}{
 				keys:    []string{"setting-a"},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errForbidden,
 			},
 			wantErr: settingError{
@@ -432,7 +432,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 			},
 			want: map[string]Setting{
 				"setting-a": {ContentType: keyVaultReferenceContentType, Value: ""},
@@ -455,7 +455,7 @@ func TestClient_GetSettings(t *testing.T) {
 				err           error
 			}{
 				keys:    []string{"setting-a"},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errServer,
 			},
 			want: nil,
@@ -479,7 +479,7 @@ func TestClient_GetSettings(t *testing.T) {
 				err           error
 			}{
 				keys:    []string{"setting-a"},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errRequest,
 			},
 			want:    nil,
@@ -505,7 +505,7 @@ func TestClient_GetSettings(t *testing.T) {
 				secrets: map[string]Secret{
 					"secret-1": {Value: "1"},
 				},
-				timeout: 30 * time.Millisecond,
+				timeout: 50 * time.Millisecond,
 				err:     errGetSecret,
 			},
 			wantErr: errGetSecret,
@@ -526,7 +526,7 @@ func TestClient_GetSettings(t *testing.T) {
 						secrets: test.input.secrets,
 						err:     test.input.err,
 					}
-					c.timeout = 10 * time.Millisecond
+					c.timeout = 100 * time.Millisecond
 				},
 			}
 			var client *Client
@@ -991,7 +991,7 @@ func (c *mockSecretClient) SetVault(vault string) {
 }
 
 func (c mockSecretClient) Get(ctx context.Context, name string, options ...secret.Option) (Secret, error) {
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	if c.err != nil && errors.Is(c.err, errGetSecret) {
 		return Secret{}, c.err
 	}

--- a/internal/setting/setting_test.go
+++ b/internal/setting/setting_test.go
@@ -641,7 +641,7 @@ func TestClient_getSecret(t *testing.T) {
 			client, _ := NewClient("config", mockCredential{}, func(c *Client) {
 				c.c = mockHttpClient{}
 				c.sc = test.input.secretClient
-				c.timeout = 10 * time.Millisecond
+				c.timeout = 100 * time.Millisecond
 			})
 
 			got, gotErr := client.getSecret(context.Background(), test.input.uri)

--- a/internal/setting/setting_test.go
+++ b/internal/setting/setting_test.go
@@ -387,7 +387,7 @@ func TestClient_GetSettings(t *testing.T) {
 					"setting-b": []byte(`{"value":"b"}`),
 					"setting-c": []byte(`{"value":"c"}`),
 				},
-				timeout: time.Nanosecond,
+				timeout: time.Millisecond,
 			},
 			wantErr: cmpopts.AnyError,
 		},
@@ -526,7 +526,7 @@ func TestClient_GetSettings(t *testing.T) {
 						secrets: test.input.secrets,
 						err:     test.input.err,
 					}
-					c.timeout = time.Millisecond * 10
+					c.timeout = 10 * time.Millisecond
 				},
 			}
 			var client *Client
@@ -641,7 +641,7 @@ func TestClient_getSecret(t *testing.T) {
 			client, _ := NewClient("config", mockCredential{}, func(c *Client) {
 				c.c = mockHttpClient{}
 				c.sc = test.input.secretClient
-				c.timeout = time.Millisecond * 10
+				c.timeout = 10 * time.Millisecond
 			})
 
 			got, gotErr := client.getSecret(context.Background(), test.input.uri)
@@ -991,6 +991,7 @@ func (c *mockSecretClient) SetVault(vault string) {
 }
 
 func (c mockSecretClient) Get(ctx context.Context, name string, options ...secret.Option) (Secret, error) {
+	time.Sleep(15 * time.Millisecond)
 	if c.err != nil && errors.Is(c.err, errGetSecret) {
 		return Secret{}, c.err
 	}

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -56,7 +56,7 @@ func CreateCertificate(options ...CreateCertificateOption) (Certificate, error) 
 			Organization: []string{"azcfg"},
 		},
 		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,

--- a/options.go
+++ b/options.go
@@ -54,13 +54,13 @@ const (
 const (
 	// defaultTimeout is the default timeout for the clients
 	// of the parser.
-	defaultTimeout = time.Second * 10
+	defaultTimeout = 30 * time.Second
 	// defaultConcurrency is the default concurrency for the
 	// clients of the parser.
 	defaultConcurrency = 20
 	// defaultManagedIdentityIMDSDialTimeout is the default dial timeout
 	// for testing the IMDS endpoint for managed identities.
-	defaultManagedIdentityIMDSDialTimeout = time.Second * 3
+	defaultManagedIdentityIMDSDialTimeout = 3 * time.Second
 )
 
 // Options contains options for the Parser.

--- a/options_test.go
+++ b/options_test.go
@@ -47,9 +47,9 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name:  "WithTimeout",
-			input: WithTimeout(time.Second * 5),
+			input: WithTimeout(5 * time.Second),
 			want: Options{
-				Timeout: time.Second * 5,
+				Timeout: 5 * time.Second,
 			},
 		},
 		{
@@ -120,11 +120,11 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name:  "WithManagedIdentityIMDSDialTimeout",
-			input: WithManagedIdentityIMDSDialTimeout(time.Second * 10),
+			input: WithManagedIdentityIMDSDialTimeout(10 * time.Second),
 			want: Options{
 				Authentication: Authentication{
 					Entra: Entra{
-						ManagedIdentityIMDSDialTimeout: time.Second * 10,
+						ManagedIdentityIMDSDialTimeout: 10 * time.Second,
 					},
 				},
 			},
@@ -211,12 +211,12 @@ func TestOptions(t *testing.T) {
 			name: "WithRetryPolicy",
 			input: WithRetryPolicy(RetryPolicy{
 				MinDelay: time.Second,
-				MaxDelay: time.Second * 5,
+				MaxDelay: 5 * time.Second,
 			}),
 			want: Options{
 				RetryPolicy: RetryPolicy{
 					MinDelay: time.Second,
-					MaxDelay: time.Second * 5,
+					MaxDelay: 5 * time.Second,
 				},
 			},
 		},

--- a/parser.go
+++ b/parser.go
@@ -139,9 +139,6 @@ func NewParser(options ...Option) (*parser, error) {
 
 // Parse secrets from an Azure Key Vault and settings from an
 // Azure App Configuration into the provided struct.
-//
-// The only valid option is context, the other options on the
-// parser remain unaffected.
 func (p *parser) Parse(ctx context.Context, v any) error {
 	return parse(ctx, v, parseOptions{
 		secretClient:  p.secretClient,

--- a/parser_test.go
+++ b/parser_test.go
@@ -48,7 +48,7 @@ func TestNewParser(t *testing.T) {
 			want: &parser{
 				secretClient:  &secret.Client{},
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -66,7 +66,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				secretClient: &secret.Client{},
-				timeout:      time.Second * 10,
+				timeout:      defaultTimeout,
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -101,7 +101,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -137,7 +137,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -156,7 +156,7 @@ func TestNewParser(t *testing.T) {
 			},
 			want: &parser{
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -167,7 +167,7 @@ func TestNewParser(t *testing.T) {
 			}{
 				options: []Option{
 					WithConcurrency(30),
-					WithTimeout(time.Second * 10),
+					WithTimeout(10 * time.Second),
 					WithClientSecretCredential(_testTenantID, _testClientID, _testClientSecret),
 					WithKeyVault("vault1"),
 					WithAppConfiguration("appconfig"),
@@ -176,7 +176,7 @@ func TestNewParser(t *testing.T) {
 			want: &parser{
 				secretClient:  &secret.Client{},
 				settingClient: &setting.Client{},
-				timeout:       time.Second * 10,
+				timeout:       10 * time.Second,
 			},
 		},
 		{
@@ -224,7 +224,7 @@ func TestNewParser(t *testing.T) {
 			want: &parser{
 				secretClient:  mockSecretClient{},
 				settingClient: nil,
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -240,7 +240,7 @@ func TestNewParser(t *testing.T) {
 			want: &parser{
 				secretClient:  nil,
 				settingClient: mockSettingClient{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 		{
@@ -257,7 +257,7 @@ func TestNewParser(t *testing.T) {
 			want: &parser{
 				secretClient:  mockSecretClient{},
 				settingClient: mockSettingClient{},
-				timeout:       time.Second * 10,
+				timeout:       defaultTimeout,
 			},
 		},
 	}


### PR DESCRIPTION
Increase default timeouts in clients to 30 seconds.

The for select have been refactored and unecessary variables removed.