### PR TITLE
feat: export interfaces for secret and setting clients and their options

### DIFF
--- a/azcfg.go
+++ b/azcfg.go
@@ -29,7 +29,7 @@ func Parse(ctx context.Context, v any, options ...Option) error {
 }
 
 // Parse secrets into the configuration.
-func parse(ctx context.Context, d any, secretClient secretClient, settingClient settingClient) error {
+func parse(ctx context.Context, d any, secretClient SecretClient, settingClient SettingClient) error {
 	v := reflect.ValueOf(d)
 	if v.Kind() != reflect.Pointer {
 		return errors.New("must provide a pointer to a struct")

--- a/options.go
+++ b/options.go
@@ -78,9 +78,9 @@ type Options struct {
 	// httpClient is the HTTP client for the parser.
 	httpClient HTTPClient
 	// SecretClient is a client used to retrieve secrets.
-	SecretClient secretClient
+	SecretClient SecretClient
 	// SettingClient is a client used to retrieve settings.
-	SettingClient settingClient
+	SettingClient SettingClient
 	// Cloud is the Azure cloud to make requests to. Defaults to AzurePublic.
 	Cloud cloud.Cloud
 	// KeyVault is the name of the Key Vault containing secrets.
@@ -354,14 +354,14 @@ func WithSettingsLabels(labels map[string]string) Option {
 }
 
 // WithSecretClient sets the client for secret retrieval.
-func WithSecretClient(c secretClient) Option {
+func WithSecretClient(c SecretClient) Option {
 	return func(o *Options) {
 		o.SecretClient = c
 	}
 }
 
 // WithSettingClient sets the client for setting retrieval.
-func WithSettingClient(c settingClient) Option {
+func WithSettingClient(c SettingClient) Option {
 	return func(o *Options) {
 		o.SettingClient = c
 	}

--- a/parser.go
+++ b/parser.go
@@ -32,17 +32,29 @@ type HTTPClient interface {
 // Secret represents a secret as returned from the Key Vault REST API.
 type Secret = secret.Secret
 
-// secretClient is the interface that wraps around method GetSecrets.
-type secretClient interface {
-	GetSecrets(ctx context.Context, names []string, options ...secret.Option) (map[string]Secret, error)
+// SecretOptions contains options for SecretClient operations.
+type SecretOptions = secret.Options
+
+// SecretOption is a function that sets an option on a SecretClient.
+type SecretOption = secret.Option
+
+// SecretClient is the interface that wraps around method GetSecrets.
+type SecretClient interface {
+	GetSecrets(ctx context.Context, names []string, options ...SecretOption) (map[string]Secret, error)
 }
 
 // Setting represents a setting as returned from the App Config REST API.
 type Setting = setting.Setting
 
-// settingClient is the interface that wraps around method GetSettings.
-type settingClient interface {
-	GetSettings(ctx context.Context, keys []string, options ...setting.Option) (map[string]Setting, error)
+// SettingOptions contains options for SettingsClient operations.
+type SettingOptions = setting.Options
+
+// SettingOption is a function that sets an option on a SettingsClient.
+type SettingOption = setting.Option
+
+// SettingClient is the interface that wraps around method GetSettings.
+type SettingClient interface {
+	GetSettings(ctx context.Context, keys []string, options ...SettingOption) (map[string]Setting, error)
 }
 
 // RetryPolicy contains rules for retries.
@@ -51,8 +63,8 @@ type RetryPolicy = httpr.RetryPolicy
 // parser contains all the necessary values and settings for calls to
 // Parse.
 type parser struct {
-	secretClient  secretClient
-	settingClient settingClient
+	secretClient  SecretClient
+	settingClient SettingClient
 	timeout       time.Duration
 }
 
@@ -79,7 +91,7 @@ func NewParser(options ...Option) (Parser, error) {
 		cred = opts.Credential
 	}
 
-	var secretClient secretClient
+	var secretClient SecretClient
 	if opts.SecretClient == nil && len(opts.KeyVault) > 0 {
 		var err error
 		if cred == nil {
@@ -109,7 +121,7 @@ func NewParser(options ...Option) (Parser, error) {
 		secretClient = opts.SecretClient
 	}
 
-	var settingClient settingClient
+	var settingClient SettingClient
 	if opts.SettingClient == nil && len(opts.AppConfiguration) > 0 || len(opts.Authentication.AppConfigurationConnectionString) > 0 {
 		var err error
 		if opts.Authentication.AppConfigurationAccessKey == (AppConfigurationAccessKey{}) && len(opts.Authentication.AppConfigurationConnectionString) == 0 {
@@ -222,7 +234,7 @@ type settings struct {
 }
 
 // newSettingClient creates a new setting client based on the provided settings.
-func newSettingClient(settings settings, options ...setting.ClientOption) (settingClient, error) {
+func newSettingClient(settings settings, options ...setting.ClientOption) (SettingClient, error) {
 	if len(settings.appConfiguration) > 0 && settings.credential != nil {
 		return setting.NewClient(
 			settings.appConfiguration,

--- a/parser.go
+++ b/parser.go
@@ -46,10 +46,10 @@ type SecretClient interface {
 // Setting represents a setting as returned from the App Config REST API.
 type Setting = setting.Setting
 
-// SettingOptions contains options for SettingsClient operations.
+// SettingOptions contains options for SettingClient operations.
 type SettingOptions = setting.Options
 
-// SettingOption is a function that sets an option on a SettingsClient.
+// SettingOption is a function that sets an option on a SettingClient.
 type SettingOption = setting.Option
 
 // SettingClient is the interface that wraps around method GetSettings.

--- a/parser_test.go
+++ b/parser_test.go
@@ -292,8 +292,8 @@ func TestParser_Parse(t *testing.T) {
 		input struct {
 			s             Struct
 			options       []Option
-			secretClient  secretClient
-			settingClient settingClient
+			secretClient  SecretClient
+			settingClient SettingClient
 		}
 		want    Struct
 		wantErr error
@@ -303,8 +303,8 @@ func TestParser_Parse(t *testing.T) {
 			input: struct {
 				s             Struct
 				options       []Option
-				secretClient  secretClient
-				settingClient settingClient
+				secretClient  SecretClient
+				settingClient SettingClient
 			}{
 				s: Struct{},
 				secretClient: newMockSecretClient(map[string]Secret{
@@ -324,8 +324,8 @@ func TestParser_Parse(t *testing.T) {
 			input: struct {
 				s             Struct
 				options       []Option
-				secretClient  secretClient
-				settingClient settingClient
+				secretClient  SecretClient
+				settingClient SettingClient
 			}{
 				s:             Struct{},
 				secretClient:  newMockSecretClient(nil, fmt.Errorf("secret error")),


### PR DESCRIPTION
This pull request exports the interfaces for secet and setting clients and their options to provide the possibility to bring "your own clients", also provides a means to mock clients when testing code that uses the `azcfg` module.